### PR TITLE
add --exclude option to ignore paths matching the specified glob pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "criterion",
+ "globset",
  "ignore",
  "predicates",
  "rayon",

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ similarity-ts . --experimental-types
 
 # Check types only
 similarity-ts . --no-functions --experimental-types
+
+# Exclude directories by glob pattern
+similarity-ts . --exclude "**/codegen/**"
 ```
 
 ## Usage

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 walkdir = "2.5"
 ignore = "0.4"
+globset = "0.4"
 rayon = "1.10"
 
 [dev-dependencies]


### PR DESCRIPTION
Great stuff!

This feature would be helpful when a user wants to ignore generated code from the input.