### PR TITLE
[RFC] Support for '// similarity-ignore' directives.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1393,6 +1393,7 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "tree-sitter",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,6 +28,7 @@ tree-sitter-ruby = { workspace = true }
 rayon = "1.10"
 ignore = "0.4"
 anyhow = "1.0"
+regex = "1.12.2"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/core/src/class_extractor.rs
+++ b/crates/core/src/class_extractor.rs
@@ -15,6 +15,7 @@ pub struct ClassDefinition {
     pub end_line: usize,
     pub file_path: String,
     pub is_abstract: bool,
+    pub has_ignore_directive: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -396,6 +397,7 @@ impl ClassExtractor {
             end_line,
             file_path: self.file_path.clone(),
             is_abstract: class.r#abstract,
+            has_ignore_directive: false,
         }
     }
 

--- a/crates/core/src/fast_similarity.rs
+++ b/crates/core/src/fast_similarity.rs
@@ -147,7 +147,9 @@ pub fn find_similar_functions_across_files_fast(
 
     // Extract functions with fingerprints from all files
     for (filename, source) in files {
-        let functions = extract_functions(filename, source)?;
+        let mut functions = extract_functions(filename, source)?;
+        // Filter out ignored functions
+        functions.retain(|f| !f.has_ignore_directive);
         for func in functions {
             if let Some(min_tokens) = options.tsed_options.min_tokens {
                 // If min_tokens is specified, use token count instead of line count

--- a/crates/core/src/function_extractor.rs
+++ b/crates/core/src/function_extractor.rs
@@ -1,5 +1,6 @@
 use oxc_ast::ast::*;
 use oxc_span::Span;
+use regex::Regex;
 
 use crate::parser::parse_and_convert_to_tree;
 use crate::tsed::{calculate_tsed, TSEDOptions};
@@ -33,6 +34,7 @@ pub struct FunctionDefinition {
     pub class_name: Option<String>,
     pub parent_function: Option<String>,
     pub node_count: Option<u32>,
+    pub has_ignore_directive: bool,
 }
 
 impl FunctionDefinition {
@@ -98,6 +100,36 @@ pub fn extract_functions(
     Ok(functions)
 }
 
+/// Check if a function/type/class has a `// similarity-ignore` directive in the comments above it
+fn has_ignore_directive(source_text: &str, start_line: u32) -> bool {
+    let lines: Vec<&str> = source_text.lines().collect();
+    let idx = (start_line - 1) as usize;
+    let comment = Regex::new(r"^//|^/^\*|^\*|^\*/|\*/$").expect("Bad ts comment regex");
+    let ignore = Regex::new(r"^// ?similarity-ignore\b").expect("Bad '//similarity-ignore' regex");
+
+    // Early exit for empty or wrap cases
+    if start_line <= 1 || idx >= lines.len() {
+        return false;
+    }
+
+    // Iterate backwards through previous lines as long as they are comments
+    let mut current_idx = idx;
+    while current_idx > 0 {
+        current_idx -= 1;
+        let line = lines[current_idx].trim();
+
+        if ignore.is_match(line) {
+            // If we hit our directive comment return true
+            return true;
+        } else if !(line.is_empty() || comment.is_match(line)) {
+            // Stop if we hit a line that is neither a comment nor empty
+            break;
+        }
+    }
+
+    return false;
+}
+
 struct ExtractionContext<'a> {
     functions: &'a mut Vec<FunctionDefinition>,
     source_text: &'a str,
@@ -117,16 +149,19 @@ fn extract_from_statement(stmt: &Statement, ctx: &mut ExtractionContext) {
             if let Some(name) = &func.id {
                 let func_name = name.name.to_string();
                 let params = extract_parameters(&func.params);
+                let start_line = get_line_number(func.span.start, ctx.source_text);
+                let has_ignore = has_ignore_directive(ctx.source_text, start_line);
                 ctx.functions.push(FunctionDefinition {
                     name: func_name.clone(),
                     function_type: FunctionType::Function,
                     parameters: params,
                     body_span: func.span,
-                    start_line: get_line_number(func.span.start, ctx.source_text),
+                    start_line,
                     end_line: get_line_number(func.span.end, ctx.source_text),
                     class_name: None,
                     parent_function: ctx.parent_function.clone(),
                     node_count: count_function_nodes(func.span, ctx.source_text),
+                    has_ignore_directive: has_ignore,
                 });
 
                 // Extract nested functions within the function body
@@ -164,16 +199,19 @@ fn extract_from_statement(stmt: &Statement, ctx: &mut ExtractionContext) {
                         method_name.clone()
                     };
 
+                    let start_line = get_line_number(method.span.start, ctx.source_text);
+                    let has_ignore = has_ignore_directive(ctx.source_text, start_line);
                     ctx.functions.push(FunctionDefinition {
                         name: method_name.clone(),
                         function_type,
                         parameters: params,
                         body_span: method.span,
-                        start_line: get_line_number(method.span.start, ctx.source_text),
+                        start_line,
                         end_line: get_line_number(method.span.end, ctx.source_text),
                         class_name: class_name.clone(),
                         parent_function: ctx.parent_function.clone(),
                         node_count: count_function_nodes(method.span, ctx.source_text),
+                        has_ignore_directive: has_ignore,
                     });
 
                     // Extract nested functions within method body
@@ -194,16 +232,19 @@ fn extract_from_statement(stmt: &Statement, ctx: &mut ExtractionContext) {
                     if let BindingPatternKind::BindingIdentifier(ident) = &decl.id.kind {
                         let params = extract_parameters(&arrow.params);
                         let arrow_name = ident.name.to_string();
+                        let start_line = get_line_number(arrow.span.start, ctx.source_text);
+                        let has_ignore = has_ignore_directive(ctx.source_text, start_line);
                         ctx.functions.push(FunctionDefinition {
                             name: arrow_name.clone(),
                             function_type: FunctionType::Arrow,
                             parameters: params,
                             body_span: arrow.span,
-                            start_line: get_line_number(arrow.span.start, ctx.source_text),
+                            start_line,
                             end_line: get_line_number(arrow.span.end, ctx.source_text),
                             class_name: None,
                             parent_function: ctx.parent_function.clone(),
                             node_count: count_function_nodes(arrow.span, ctx.source_text),
+                            has_ignore_directive: has_ignore,
                         });
 
                         // Extract nested functions within arrow function body
@@ -231,16 +272,19 @@ fn extract_from_statement(stmt: &Statement, ctx: &mut ExtractionContext) {
                     .unwrap_or_else(|| "default".to_string());
                 let params = extract_parameters(&func.params);
                 let func_name = name.clone();
+                let start_line = get_line_number(func.span.start, ctx.source_text);
+                let has_ignore = has_ignore_directive(ctx.source_text, start_line);
                 ctx.functions.push(FunctionDefinition {
                     name: func_name.clone(),
                     function_type: FunctionType::Function,
                     parameters: params,
                     body_span: func.span,
-                    start_line: get_line_number(func.span.start, ctx.source_text),
+                    start_line,
                     end_line: get_line_number(func.span.end, ctx.source_text),
                     class_name: None,
                     parent_function: ctx.parent_function.clone(),
                     node_count: count_function_nodes(func.span, ctx.source_text),
+                    has_ignore_directive: has_ignore,
                 });
 
                 // Extract nested functions within the function body
@@ -262,16 +306,19 @@ fn extract_from_declaration(decl: &Declaration, ctx: &mut ExtractionContext) {
             if let Some(name) = &func.id {
                 let func_name = name.name.to_string();
                 let params = extract_parameters(&func.params);
+                let start_line = get_line_number(func.span.start, ctx.source_text);
+                let has_ignore = has_ignore_directive(ctx.source_text, start_line);
                 ctx.functions.push(FunctionDefinition {
                     name: func_name.clone(),
                     function_type: FunctionType::Function,
                     parameters: params,
                     body_span: func.span,
-                    start_line: get_line_number(func.span.start, ctx.source_text),
+                    start_line,
                     end_line: get_line_number(func.span.end, ctx.source_text),
                     class_name: None,
                     parent_function: ctx.parent_function.clone(),
                     node_count: count_function_nodes(func.span, ctx.source_text),
+                    has_ignore_directive: has_ignore,
                 });
 
                 // Extract nested functions within the function body
@@ -309,16 +356,19 @@ fn extract_from_declaration(decl: &Declaration, ctx: &mut ExtractionContext) {
                         method_name.clone()
                     };
 
+                    let start_line = get_line_number(method.span.start, ctx.source_text);
+                    let has_ignore = has_ignore_directive(ctx.source_text, start_line);
                     ctx.functions.push(FunctionDefinition {
                         name: method_name.clone(),
                         function_type,
                         parameters: params,
                         body_span: method.span,
-                        start_line: get_line_number(method.span.start, ctx.source_text),
+                        start_line,
                         end_line: get_line_number(method.span.end, ctx.source_text),
                         class_name: class_name.clone(),
                         parent_function: ctx.parent_function.clone(),
                         node_count: count_function_nodes(method.span, ctx.source_text),
+                        has_ignore_directive: has_ignore,
                     });
 
                     // Extract nested functions within method body
@@ -339,16 +389,19 @@ fn extract_from_declaration(decl: &Declaration, ctx: &mut ExtractionContext) {
                     if let BindingPatternKind::BindingIdentifier(ident) = &decl.id.kind {
                         let params = extract_parameters(&arrow.params);
                         let arrow_name = ident.name.to_string();
+                        let start_line = get_line_number(arrow.span.start, ctx.source_text);
+                        let has_ignore = has_ignore_directive(ctx.source_text, start_line);
                         ctx.functions.push(FunctionDefinition {
                             name: arrow_name.clone(),
                             function_type: FunctionType::Arrow,
                             parameters: params,
                             body_span: arrow.span,
-                            start_line: get_line_number(arrow.span.start, ctx.source_text),
+                            start_line,
                             end_line: get_line_number(arrow.span.end, ctx.source_text),
                             class_name: None,
                             parent_function: ctx.parent_function.clone(),
                             node_count: count_function_nodes(arrow.span, ctx.source_text),
+                            has_ignore_directive: has_ignore,
                         });
 
                         // Extract nested functions within arrow function body
@@ -503,7 +556,9 @@ pub fn find_similar_functions_in_file(
     threshold: f64,
     options: &TSEDOptions,
 ) -> Result<Vec<SimilarityResult>, String> {
-    let functions = extract_functions(filename, source_text)?;
+    let mut functions = extract_functions(filename, source_text)?;
+    // Filter out ignored functions
+    functions.retain(|f| !f.has_ignore_directive);
     let mut similar_pairs = Vec::new();
 
     // Compare all pairs
@@ -564,7 +619,9 @@ pub fn find_similar_functions_across_files(
 
     // Extract functions from all files
     for (filename, source) in files {
-        let functions = extract_functions(filename, source)?;
+        let mut functions = extract_functions(filename, source)?;
+        // Filter out ignored functions
+        functions.retain(|f| !f.has_ignore_directive);
         for func in functions {
             all_functions.push((filename.clone(), source.clone(), func));
         }

--- a/crates/core/src/structure_comparator_tests.rs
+++ b/crates/core/src/structure_comparator_tests.rs
@@ -130,6 +130,7 @@ mod tests {
             start_line: 1,
             end_line: 5,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         };
         
         let type2 = TypeDefinition {
@@ -148,6 +149,7 @@ mod tests {
             start_line: 10,
             end_line: 15,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         };
         
         let result = comparator.compare_types(&type1, &type2);

--- a/crates/core/src/type_comparator.rs
+++ b/crates/core/src/type_comparator.rs
@@ -378,6 +378,7 @@ pub fn compare_type_literal_with_type(
         start_line: type_literal.start_line,
         end_line: type_literal.end_line,
         file_path: type_literal.file_path.clone(),
+        has_ignore_directive: false,
     };
 
     compare_types(&temp_type_def, type_definition, options)
@@ -456,6 +457,7 @@ pub fn find_similar_type_literals_pairs(
                     start_line: type_literal2.start_line,
                     end_line: type_literal2.end_line,
                     file_path: type_literal2.file_path.clone(),
+                    has_ignore_directive: false,
                 },
                 options,
             );
@@ -495,6 +497,7 @@ mod tests {
             start_line: 1,
             end_line: 10,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         }
     }
 

--- a/crates/core/src/type_extractor.rs
+++ b/crates/core/src/type_extractor.rs
@@ -17,6 +17,7 @@ pub struct TypeDefinition {
     pub start_line: usize,
     pub end_line: usize,
     pub file_path: String,
+    pub has_ignore_directive: bool,
 }
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeKind {
@@ -152,6 +153,7 @@ impl TypeExtractor {
             start_line,
             end_line,
             file_path: self.file_path.clone(),
+            has_ignore_directive: false,
         })
     }
 
@@ -172,6 +174,7 @@ impl TypeExtractor {
             start_line,
             end_line,
             file_path: self.file_path.clone(),
+            has_ignore_directive: false,
         })
     }
 

--- a/crates/core/src/type_fingerprint.rs
+++ b/crates/core/src/type_fingerprint.rs
@@ -206,6 +206,7 @@ mod tests {
             start_line: 1,
             end_line: 5,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         };
 
         let fingerprint = generate_type_fingerprint(&type_def);

--- a/crates/core/src/type_normalizer.rs
+++ b/crates/core/src/type_normalizer.rs
@@ -446,6 +446,7 @@ mod tests {
             start_line: 1,
             end_line: 10,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         }
     }
 

--- a/crates/core/src/typescript_structure_adapter.rs
+++ b/crates/core/src/typescript_structure_adapter.rs
@@ -352,6 +352,7 @@ mod tests {
             start_line: 1,
             end_line: 5,
             file_path: "user.ts".to_string(),
+            has_ignore_directive: false,
         };
         
         let structure = Structure::from(type_def);
@@ -388,6 +389,7 @@ mod tests {
             start_line: 1,
             end_line: 5,
             file_path: "user.ts".to_string(),
+            has_ignore_directive: false,
         };
         
         let type2 = TypeDefinition {
@@ -412,6 +414,7 @@ mod tests {
             start_line: 10,
             end_line: 15,
             file_path: "person.ts".to_string(),
+            has_ignore_directive: false,
         };
         
         let result = comparator.compare_types(&type1, &type2);

--- a/crates/core/src/unified_type_comparator.rs
+++ b/crates/core/src/unified_type_comparator.rs
@@ -94,6 +94,7 @@ fn type_literal_to_type_def(literal: &TypeLiteralDefinition) -> TypeDefinition {
         start_line: literal.start_line,
         end_line: literal.end_line,
         file_path: literal.file_path.clone(),
+        has_ignore_directive: false,
     }
 }
 

--- a/crates/similarity-ts/src/check.rs
+++ b/crates/similarity-ts/src/check.rs
@@ -267,6 +267,7 @@ pub fn check_paths(
     filter_function: Option<&String>,
     filter_function_body: Option<&String>,
     exclude_patterns: &[String],
+    show_ignored: bool,
 ) -> anyhow::Result<usize> {
     let default_extensions = vec!["ts", "tsx", "js", "jsx", "mjs", "cjs", "mts", "cts"];
     let exts: Vec<&str> =
@@ -394,5 +395,41 @@ pub fn check_paths(
     let duplicate_count =
         display_all_results(all_results, print, filter_function, filter_function_body);
 
+    // Report ignored functions if requested
+    if show_ignored {
+        report_ignored_items(&files);
+    }
+
     Ok(duplicate_count)
+}
+
+fn report_ignored_items(files: &[PathBuf]) {
+    use similarity_core::function_extractor::extract_functions;
+
+    let mut ignored_count = 0;
+    let mut ignored_items = Vec::new();
+
+    for file in files {
+        if let Ok(content) = std::fs::read_to_string(file) {
+            if let Ok(functions) = extract_functions(file.to_str().unwrap_or(""), &content) {
+                for func in functions {
+                    if func.has_ignore_directive {
+                        ignored_count += 1;
+                        ignored_items.push((
+                            file.display().to_string(),
+                            func.name.clone(),
+                            func.start_line,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    if ignored_count > 0 {
+        println!("Ignored {ignored_count} function(s) via similarity-ignore directive:");
+        for (file, name, line) in ignored_items {
+            println!("  {}:{} {}", file, line, name);
+        }
+    }
 }

--- a/crates/similarity-ts/src/main.rs
+++ b/crates/similarity-ts/src/main.rs
@@ -82,6 +82,10 @@ struct Cli {
     #[arg(long)]
     filter_function_body: Option<String>,
 
+    /// Show functions/types/classes that were ignored via similarity-ignore comments
+    #[arg(long)]
+    show_ignored: bool,
+
     /// Include both interfaces and type aliases (deprecated - both are included by default)
     #[arg(long, hide = true)]
     include_types: bool,
@@ -200,6 +204,7 @@ fn main() -> anyhow::Result<()> {
             cli.filter_function.as_ref(),
             cli.filter_function_body.as_ref(),
             &cli.exclude,
+            cli.show_ignored,
         )?;
         total_duplicates += duplicate_count;
     }

--- a/crates/similarity-ts/src/parallel.rs
+++ b/crates/similarity-ts/src/parallel.rs
@@ -24,7 +24,11 @@ pub fn load_files_parallel(files: &[PathBuf]) -> Vec<FileData> {
                     let filename = file.to_string_lossy();
                     // Extract functions, skip if parse error
                     match extract_functions(&filename, &content) {
-                        Ok(functions) => Some(FileData { path: file.clone(), content, functions }),
+                        Ok(mut functions) => {
+                            // Filter out ignored functions
+                            functions.retain(|f| !f.has_ignore_directive);
+                            Some(FileData { path: file.clone(), content, functions })
+                        }
                         Err(_) => None, // Skip files with parse errors
                     }
                 }

--- a/examples/test_ignore_directive.ts
+++ b/examples/test_ignore_directive.ts
@@ -1,0 +1,70 @@
+// Test file for similarity-ignore directive
+
+// This function should be detected as similar to calculatePrice
+function calculateTotal(items: any[]): number {
+  return items.reduce((sum, item) => sum + item.price, 0);
+}
+
+// similarity-ignore
+// This function is intentionally similar but should be ignored
+function calculatePrice(products: any[]): number {
+  return products.reduce((sum, p) => sum + p.price, 0);
+}
+
+/**
+ * Calculate the sum of all values
+ */
+// similarity-ignore
+function computeSum(values: any[]): number {
+  return values.reduce((sum, v) => sum + v.price, 0);
+}
+
+// Regular function without ignore directive
+function sumPrices(items: any[]): number {
+  return items.reduce((total, item) => total + item.price, 0);
+}
+
+// Test with JSDoc and ignore directive
+/**
+ * This is a documented function
+ * @param orders Array of orders
+ * @returns Total price
+ */
+// similarity-ignore
+function getTotalPrice(orders: any[]): number {
+  return orders.reduce((sum, order) => sum + order.price, 0);
+}
+
+// Arrow function without ignore
+const calculateCost = (items: any[]) => {
+  return items.reduce((sum, item) => sum + item.price, 0);
+};
+
+// similarity-ignore
+// Arrow function with ignore
+const computeCost = (products: any[]) => {
+  return products.reduce((sum, p) => sum + p.price, 0);
+};
+
+class PriceCalculator {
+  // Method without ignore
+  calculateTotal(items: any[]): number {
+    return items.reduce((sum, item) => sum + item.price, 0);
+  }
+
+  // similarity-ignore
+  // Method with ignore directive
+  computeTotal(items: any[]): number {
+    return items.reduce((sum, item) => sum + item.price, 0);
+  }
+}
+
+// Export function without ignore
+export function calculateOrderTotal(orders: any[]): number {
+  return orders.reduce((sum, order) => sum + order.price, 0);
+}
+
+// similarity-ignore
+export function computeOrderTotal(orders: any[]): number {
+  return orders.reduce((sum, order) => sum + order.price, 0);
+}


### PR DESCRIPTION
I've noticed that while `similarity-ts` is an excellent tool for catching potentially duplicated code, it does seem to produce some false positives. Sometimes, having utility code duplicated locally in a couple of places is fine before you have enough examples to make an interface. My ideal workflow would be to evaluate the cases it presents and then decide whether to:

1. Refactor or
2. Mark the function or type as fine (similar to eslint)

My proposal here is to just add a `// similarity-ignore` declaration comment that tells us to ignore the following function or type. There are some examples in the `test_ignore_directives.ts` file.

Output)
```sh
cargo run --package similarity-ts -- . --no-types --show-ignored
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/similarity-ts . --no-types --show-ignored`
Analyzing code similarity...

=== Function Similarity ===
Checking 151 files for duplicates...

Found 3 duplicate pairs:
------------------------------------------------------------

Similarity: 88.60%, Score: 34.6 points (lines 36~42, avg: 39.0)
  ./__deprecated/src/cli/repo_checker.ts:178-213 addFile
  ./__deprecated/src/cli/repo_checker.ts:266-307 addFileWithASTAsync

Similarity: 91.75%, Score: 24.8 points (lines 27~27, avg: 27.0)
  ./test/__fixtures__/duplication/semantic/validation_pattern_1.ts:3-29 validateUserRegistration
  ./test/__fixtures__/duplication/semantic/validation_pattern_1.ts:31-57 validateProductCreation

Similarity: 99.29%, Score: 14.4 points (lines 14~15, avg: 14.5)
  ./__deprecated/src/core/apted.ts:304-317 calculateAPTEDSimilarityFromAST
  ./__deprecated/src/core/tsed.ts:29-43 calculateTSED
Ignored 6 function(s) via similarity-ignore directive:
  ./examples/test_ignore_directive.ts:10 calculatePrice
  ./examples/test_ignore_directive.ts:18 computeSum
  ./examples/test_ignore_directive.ts:34 getTotalPrice
  ./examples/test_ignore_directive.ts:45 computeCost
  ./examples/test_ignore_directive.ts:57 computeTotal
  ./examples/test_ignore_directive.ts:68 computeOrderTotal
```

If this seems like a reasonable addition I can add some proper test cases and add support for other languages (vs just typescript).

NOTE: I think there might be an issue with the other examples. Even on the parent commit, I'm not getting anything detected for.

```
cargo run --package similarity-ts examples/spec/duplicate-functions.ts --threshold 0.8 --min-tokens 20
```