### PR TITLE
feat: add ConfigLoader trait in core and similarity.toml support for …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,6 +1370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1404,8 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
+ "toml",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
@@ -1527,6 +1538,7 @@ dependencies = [
  "ignore",
  "predicates",
  "rayon",
+ "serde",
  "similarity-core",
  "tempfile",
  "tree-sitter",
@@ -1763,6 +1775,47 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tree-sitter"
@@ -2176,6 +2229,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,6 +18,7 @@ oxc_span = { workspace = true }
 oxc_allocator = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.8"
 tree-sitter = { workspace = true }
 tree-sitter-go = { workspace = true }
 tree-sitter-java = { workspace = true }
@@ -31,6 +32,7 @@ anyhow = "1.0"
 
 [dev-dependencies]
 criterion = "0.5"
+tempfile = "3"
 
 [[bench]]
 name = "tsed_benchmark"

--- a/crates/core/src/config_loader.rs
+++ b/crates/core/src/config_loader.rs
@@ -1,0 +1,220 @@
+use std::path::PathBuf;
+
+/// Implement this trait on any struct that derives `serde::Deserialize` and `Default`
+/// to get automatic `similarity.toml` config file loading.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[derive(serde::Deserialize, Default)]
+/// struct Config {
+///     threshold: Option<f64>,
+///     min_lines: Option<u32>,
+/// }
+///
+/// impl similarity_core::ConfigLoader for Config {}
+///
+/// // In main():
+/// let config = Config::find_and_load();
+/// ```
+pub trait ConfigLoader: Sized + Default + serde::de::DeserializeOwned {
+    /// Walk up from the current directory looking for `similarity.toml`.
+    /// Returns the first file found, or `None` if none exists in any ancestor.
+    fn find_config_file() -> Option<PathBuf> {
+        let mut dir = std::env::current_dir().ok()?;
+        loop {
+            let candidate = dir.join("similarity.toml");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+            if !dir.pop() {
+                return None;
+            }
+        }
+    }
+
+    /// Read and deserialize a `similarity.toml` at the given path.
+    fn load_from_file(path: PathBuf) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", path.display(), e))?;
+        let config: Self = toml::from_str(&content)
+            .map_err(|e| anyhow::anyhow!("Failed to parse {}: {}", path.display(), e))?;
+        Ok(config)
+    }
+
+    /// Find and load the nearest `similarity.toml`, returning `Default` if none is found.
+    /// Parse errors are printed as warnings and also fall back to `Default`.
+    fn find_and_load() -> Self {
+        if let Some(path) = Self::find_config_file() {
+            Self::load_from_file(path.clone())
+                .unwrap_or_else(|e| {
+                    eprintln!("Warning: could not load {}: {e}", path.display());
+                    Self::default()
+                })
+        } else {
+            Self::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    // set_current_dir is process-global — serialize any test that changes it.
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+    #[derive(serde::Deserialize, Default, Debug, PartialEq)]
+    struct TestConfig {
+        threshold: Option<f64>,
+        min_lines: Option<u32>,
+        skip_test: Option<bool>,
+        exclude: Option<Vec<String>>,
+    }
+
+    impl ConfigLoader for TestConfig {}
+
+    /// Write `content` to a `similarity.toml` in a fresh temp dir.
+    /// Returns `(TempDir, path_to_dir)` — keep `TempDir` alive for the test duration.
+    fn write_config(content: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("similarity.toml"), content).unwrap();
+        let dir_path = dir.path().to_path_buf();
+        (dir, dir_path)
+    }
+
+    // ── find_config_file ──────────────────────────────────────────────────────
+
+    #[test]
+    fn finds_config_in_current_dir() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let (_dir, dir_path) = write_config("threshold = 0.9");
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir_path).unwrap();
+
+        let found = TestConfig::find_config_file();
+
+        std::env::set_current_dir(&original).unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().file_name().unwrap(), "similarity.toml");
+    }
+
+    #[test]
+    fn returns_none_when_no_config_exists() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let found = TestConfig::find_config_file();
+
+        std::env::set_current_dir(&original).unwrap();
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn finds_config_in_parent_dir() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let (_dir, dir_path) = write_config("threshold = 0.9");
+        let subdir = dir_path.join("subproject");
+        fs::create_dir_all(&subdir).unwrap();
+
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&subdir).unwrap();
+
+        let found = TestConfig::find_config_file();
+
+        std::env::set_current_dir(&original).unwrap();
+        assert!(found.is_some());
+    }
+
+    // ── load_from_file ────────────────────────────────────────────────────────
+
+    #[test]
+    fn loads_all_supported_fields() {
+        let (_dir, dir_path) = write_config(
+            r#"
+threshold = 0.92
+min_lines = 10
+skip_test = true
+exclude = ["target/", "tests/fixtures/"]
+"#,
+        );
+
+        let config = TestConfig::load_from_file(dir_path.join("similarity.toml")).unwrap();
+
+        assert_eq!(config.threshold, Some(0.92));
+        assert_eq!(config.min_lines, Some(10));
+        assert_eq!(config.skip_test, Some(true));
+        assert_eq!(
+            config.exclude,
+            Some(vec!["target/".to_string(), "tests/fixtures/".to_string()])
+        );
+    }
+
+    #[test]
+    fn partial_config_leaves_unset_fields_as_none() {
+        let (_dir, dir_path) = write_config("threshold = 0.75");
+
+        let config = TestConfig::load_from_file(dir_path.join("similarity.toml")).unwrap();
+
+        assert_eq!(config.threshold, Some(0.75));
+        assert_eq!(config.min_lines, None);
+        assert_eq!(config.skip_test, None);
+    }
+
+    #[test]
+    fn empty_config_file_gives_all_none() {
+        let (_dir, dir_path) = write_config("");
+
+        let config = TestConfig::load_from_file(dir_path.join("similarity.toml")).unwrap();
+
+        assert_eq!(config, TestConfig::default());
+    }
+
+    #[test]
+    fn invalid_toml_returns_error() {
+        let (_dir, dir_path) = write_config("this is not : valid toml !!!");
+
+        let result = TestConfig::load_from_file(dir_path.join("similarity.toml"));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_file_returns_error() {
+        let path = PathBuf::from("/tmp/this_does_not_exist_similarity_test.toml");
+        assert!(TestConfig::load_from_file(path).is_err());
+    }
+
+    // ── find_and_load ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn find_and_load_returns_default_when_no_file() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let config = TestConfig::find_and_load();
+
+        std::env::set_current_dir(&original).unwrap();
+        assert_eq!(config, TestConfig::default());
+    }
+
+    #[test]
+    fn find_and_load_reads_config_from_cwd() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let (_dir, dir_path) = write_config("threshold = 0.88\nmin_lines = 7");
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir_path).unwrap();
+
+        let config = TestConfig::find_and_load();
+
+        std::env::set_current_dir(&original).unwrap();
+        assert_eq!(config.threshold, Some(0.88));
+        assert_eq!(config.min_lines, Some(7));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,6 +27,9 @@ pub mod typescript_structure_adapter;
 pub mod rust_structure_adapter;
 pub mod css_structure_adapter;
 
+pub mod config_loader;
+pub use config_loader::ConfigLoader;
+
 // CLI utilities
 pub mod cli_file_utils;
 pub mod cli_output;

--- a/crates/similarity-rs/Cargo.toml
+++ b/crates/similarity-rs/Cargo.toml
@@ -21,6 +21,7 @@ name = "similarity_rs"
 [dependencies]
 similarity-core = { version = "0.4.2", path = "../core" }
 clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 rayon = "1.10"
 ignore = "0.4"

--- a/crates/similarity-rs/src/config.rs
+++ b/crates/similarity-rs/src/config.rs
@@ -1,0 +1,195 @@
+use clap::Parser;
+use similarity_core::ConfigLoader;
+
+#[derive(Parser)]
+#[command(name = "similarity-rs")]
+#[command(about = "Rust code similarity analyzer")]
+#[command(version)]
+pub struct Cli {
+    /// Paths to analyze (files or directories)
+    #[arg(default_value = ".")]
+    pub paths: Vec<String>,
+
+    /// Print code in output
+    #[arg(short, long)]
+    pub print: bool,
+
+    /// Similarity threshold (0.0-1.0)
+    #[arg(short, long)]
+    pub threshold: Option<f64>,
+
+    /// File extensions to check
+    #[arg(short, long, value_delimiter = ',')]
+    pub extensions: Option<Vec<String>>,
+
+    /// Minimum lines for functions to be considered
+    #[arg(short, long)]
+    pub min_lines: Option<u32>,
+
+    /// Minimum tokens for functions to be considered
+    #[arg(long)]
+    pub min_tokens: Option<u32>,
+
+    /// Rename cost for APTED algorithm
+    #[arg(short, long)]
+    pub rename_cost: Option<f64>,
+
+    /// Disable size penalty for very different sized functions
+    #[arg(long)]
+    pub no_size_penalty: bool,
+
+    /// Filter functions by name (substring match)
+    #[arg(long)]
+    pub filter_function: Option<String>,
+
+    /// Filter functions by body content (substring match)
+    #[arg(long)]
+    pub filter_function_body: Option<String>,
+
+    /// Disable fast mode with bloom filter pre-filtering
+    #[arg(long)]
+    pub no_fast: bool,
+
+    /// Exclude directories matching the given patterns (can be specified multiple times)
+    #[arg(long)]
+    pub exclude: Vec<String>,
+
+    /// Skip test functions (functions starting with 'test_' or annotated with #[test])
+    #[arg(long)]
+    pub skip_test: bool,
+
+    /// Enable experimental overlap detection mode
+    #[arg(long = "experimental-overlap")]
+    pub overlap: bool,
+
+    /// Minimum window size for overlap detection (number of nodes)
+    #[arg(long)]
+    pub overlap_min_window: Option<u32>,
+
+    /// Maximum window size for overlap detection (number of nodes)
+    #[arg(long)]
+    pub overlap_max_window: Option<u32>,
+
+    /// Size tolerance for overlap detection (0.0-1.0)
+    #[arg(long)]
+    pub overlap_size_tolerance: Option<f64>,
+
+    /// Exit with code 1 if duplicates are found
+    #[arg(long)]
+    pub fail_on_duplicates: bool,
+
+    /// Enable type similarity checking for structs and enums (experimental)
+    #[arg(long = "experimental-types")]
+    pub types: bool,
+
+    /// Disable function similarity checking
+    #[arg(long = "no-functions")]
+    pub no_functions: bool,
+
+    /// Use new generalized structure comparison framework (experimental)
+    #[arg(long)]
+    pub use_structure_comparison: bool,
+}
+
+/// Settings loaded from `similarity.toml`.
+/// All fields are `Option<T>` — missing keys simply stay `None`.
+///
+/// Example `similarity.toml`:
+/// ```toml
+/// threshold = 0.90
+/// min_lines = 5
+/// min_tokens = 50
+/// skip_test = true
+/// exclude = ["target/", "tests/fixtures/"]
+/// ```
+#[derive(serde::Deserialize, Default)]
+pub struct Config {
+    pub threshold: Option<f64>,
+    pub min_lines: Option<u32>,
+    pub min_tokens: Option<u32>,
+    pub rename_cost: Option<f64>,
+    pub no_size_penalty: Option<bool>,
+    pub skip_test: Option<bool>,
+    pub no_fast: Option<bool>,
+    pub fail_on_duplicates: Option<bool>,
+    pub exclude: Option<Vec<String>>,
+    pub extensions: Option<Vec<String>>,
+    pub filter_function: Option<String>,
+    pub filter_function_body: Option<String>,
+    pub overlap: Option<bool>,
+    pub overlap_min_window: Option<u32>,
+    pub overlap_max_window: Option<u32>,
+    pub overlap_size_tolerance: Option<f64>,
+    pub types: Option<bool>,
+    pub no_functions: Option<bool>,
+    pub use_structure_comparison: Option<bool>,
+}
+
+impl ConfigLoader for Config {}
+
+/// Resolved settings after merging CLI args over config file values.
+/// All fields are concrete — defaults have been applied.
+pub struct ResolvedConfig {
+    pub threshold: f64,
+    pub min_lines: u32,
+    pub min_tokens: Option<u32>,
+    pub rename_cost: f64,
+    pub no_size_penalty: bool,
+    pub skip_test: bool,
+    pub no_fast: bool,
+    pub fail_on_duplicates: bool,
+    pub overlap: bool,
+    pub types_enabled: bool,
+    pub no_functions: bool,
+    pub use_structure_comparison: bool,
+    pub overlap_min_window: u32,
+    pub overlap_max_window: u32,
+    pub overlap_size_tolerance: f64,
+    pub exclude: Vec<String>,
+    pub extensions: Option<Vec<String>>,
+    pub filter_function: Option<String>,
+    pub filter_function_body: Option<String>,
+}
+
+/// CLI value wins over config value; falls back to `default` if neither is set.
+fn resolve<T>(cli: Option<T>, cfg: Option<T>, default: T) -> T {
+    cli.or(cfg).unwrap_or(default)
+}
+
+/// CLI bool flag wins; config can also enable it when CLI didn't pass it.
+fn resolve_flag(cli: bool, cfg: Option<bool>) -> bool {
+    cli || cfg.unwrap_or(false)
+}
+
+impl ResolvedConfig {
+    /// Merge CLI args over config file values. CLI always wins.
+    /// For bool presence flags (already `true` if passed on CLI), config can also enable them.
+    /// Exclude lists are merged: config entries first, CLI entries appended (CLI has final say).
+    pub fn from(cli: Cli, cfg: Config) -> Self {
+        // Config exclude entries first, CLI entries appended — so CLI patterns take precedence.
+        let mut exclude = cfg.exclude.unwrap_or_default();
+        exclude.extend(cli.exclude);
+
+        Self {
+            threshold:                resolve(cli.threshold, cfg.threshold, 0.85),
+            min_lines:                resolve(cli.min_lines, cfg.min_lines, 3),
+            min_tokens:               cli.min_tokens.or(cfg.min_tokens),
+            rename_cost:              resolve(cli.rename_cost, cfg.rename_cost, 0.3),
+            no_size_penalty:          resolve_flag(cli.no_size_penalty, cfg.no_size_penalty),
+            skip_test:                resolve_flag(cli.skip_test, cfg.skip_test),
+            no_fast:                  resolve_flag(cli.no_fast, cfg.no_fast),
+            fail_on_duplicates:       resolve_flag(cli.fail_on_duplicates, cfg.fail_on_duplicates),
+            overlap:                  resolve_flag(cli.overlap, cfg.overlap),
+            types_enabled:            resolve_flag(cli.types, cfg.types),
+            no_functions:             resolve_flag(cli.no_functions, cfg.no_functions),
+            use_structure_comparison: resolve_flag(cli.use_structure_comparison, cfg.use_structure_comparison),
+            overlap_min_window:       resolve(cli.overlap_min_window, cfg.overlap_min_window, 8),
+            overlap_max_window:       resolve(cli.overlap_max_window, cfg.overlap_max_window, 25),
+            overlap_size_tolerance:   resolve(cli.overlap_size_tolerance, cfg.overlap_size_tolerance, 0.25),
+            exclude,
+            extensions:               cli.extensions.or(cfg.extensions),
+            filter_function:          cli.filter_function.or(cfg.filter_function),
+            filter_function_body:     cli.filter_function_body.or(cfg.filter_function_body),
+        }
+    }
+}

--- a/crates/similarity-rs/src/main.rs
+++ b/crates/similarity-rs/src/main.rs
@@ -1,110 +1,25 @@
 use anyhow::Result;
 use clap::Parser;
+use similarity_core::ConfigLoader;
 
 mod check;
 mod check_types;
+mod config;
 mod parallel;
 mod rust_parser;
 
-#[derive(Parser)]
-#[command(name = "similarity-rs")]
-#[command(about = "Rust code similarity analyzer")]
-#[command(version)]
-struct Cli {
-    /// Paths to analyze (files or directories)
-    #[arg(default_value = ".")]
-    paths: Vec<String>,
-
-    /// Print code in output
-    #[arg(short, long)]
-    print: bool,
-
-    /// Similarity threshold (0.0-1.0)
-    #[arg(short, long, default_value = "0.85")]
-    threshold: f64,
-
-    /// File extensions to check
-    #[arg(short, long, value_delimiter = ',')]
-    extensions: Option<Vec<String>>,
-
-    /// Minimum lines for functions to be considered
-    #[arg(short, long, default_value = "3")]
-    min_lines: Option<u32>,
-
-    /// Minimum tokens for functions to be considered
-    #[arg(long, default_value = "30")]
-    min_tokens: Option<u32>,
-
-    /// Rename cost for APTED algorithm
-    #[arg(short, long, default_value = "0.3")]
-    rename_cost: f64,
-
-    /// Disable size penalty for very different sized functions
-    #[arg(long)]
-    no_size_penalty: bool,
-
-    /// Filter functions by name (substring match)
-    #[arg(long)]
-    filter_function: Option<String>,
-
-    /// Filter functions by body content (substring match)
-    #[arg(long)]
-    filter_function_body: Option<String>,
-
-    /// Disable fast mode with bloom filter pre-filtering
-    #[arg(long)]
-    no_fast: bool,
-
-    /// Exclude directories matching the given patterns (can be specified multiple times)
-    #[arg(long)]
-    exclude: Vec<String>,
-
-    /// Skip test functions (functions starting with 'test_' or annotated with #[test])
-    #[arg(long)]
-    skip_test: bool,
-
-    /// Enable experimental overlap detection mode
-    #[arg(long = "experimental-overlap")]
-    overlap: bool,
-
-    /// Minimum window size for overlap detection (number of nodes)
-    #[arg(long, default_value = "8")]
-    overlap_min_window: u32,
-
-    /// Maximum window size for overlap detection (number of nodes)
-    #[arg(long, default_value = "25")]
-    overlap_max_window: u32,
-
-    /// Size tolerance for overlap detection (0.0-1.0)
-    #[arg(long, default_value = "0.25")]
-    overlap_size_tolerance: f64,
-
-    /// Exit with code 1 if duplicates are found
-    #[arg(long)]
-    fail_on_duplicates: bool,
-
-    /// Enable type similarity checking for structs and enums (experimental)
-    #[arg(long = "experimental-types")]
-    types: bool,
-
-    /// Disable function similarity checking
-    #[arg(long = "no-functions")]
-    no_functions: bool,
-    
-    /// Use new generalized structure comparison framework (experimental)
-    #[arg(long)]
-    use_structure_comparison: bool,
-}
+use config::{Cli, Config, ResolvedConfig};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    let print = cli.print;
+    let paths = cli.paths.clone();
+    let cfg = Config::find_and_load();
+    let r = ResolvedConfig::from(cli, cfg);
 
-    let functions_enabled = !cli.no_functions;
-    let types_enabled = cli.types;
-    let overlap_enabled = cli.overlap;
+    let functions_enabled = !r.no_functions;
 
-    // Validate that at least one analyzer is enabled
-    if !functions_enabled && !types_enabled && !overlap_enabled {
+    if !functions_enabled && !r.types_enabled && !r.overlap {
         eprintln!("Error: At least one analyzer must be enabled. Use --experimental-types to enable type checking, --experimental-overlap for overlap detection, or remove --no-functions.");
         return Err(anyhow::anyhow!("No analyzer enabled"));
     }
@@ -114,67 +29,60 @@ fn main() -> Result<()> {
     let separator = "-".repeat(60);
     let mut total_duplicates = 0;
 
-    // Run functions analysis
     if functions_enabled {
         println!("=== Function Similarity ===");
-        let duplicate_count = check::check_paths(
-            cli.paths.clone(),
-            cli.threshold,
-            cli.rename_cost,
-            cli.extensions.as_ref(),
-            cli.min_lines.unwrap_or(3),
-            cli.min_tokens,
-            cli.no_size_penalty,
-            cli.print,
-            !cli.no_fast,
-            cli.filter_function.as_ref(),
-            cli.filter_function_body.as_ref(),
-            &cli.exclude,
-            cli.skip_test,
+        total_duplicates += check::check_paths(
+            paths.clone(),
+            r.threshold,
+            r.rename_cost,
+            r.extensions.as_ref(),
+            r.min_lines,
+            r.min_tokens,
+            r.no_size_penalty,
+            print,
+            !r.no_fast,
+            r.filter_function.as_ref(),
+            r.filter_function_body.as_ref(),
+            &r.exclude,
+            r.skip_test,
         )?;
-        total_duplicates += duplicate_count;
     }
 
-    // Run types analysis if enabled
-    if types_enabled && functions_enabled {
+    if r.types_enabled && functions_enabled {
         println!("\n{separator}\n");
     }
 
-    if types_enabled {
+    if r.types_enabled {
         println!("=== Type Similarity (Structs & Enums) ===");
-        let type_duplicate_count = check_types::check_types(
-            cli.paths.clone(),
-            cli.threshold,
-            cli.extensions.as_ref(),
-            cli.print,
-            &cli.exclude,
-            cli.use_structure_comparison,
+        total_duplicates += check_types::check_types(
+            paths.clone(),
+            r.threshold,
+            r.extensions.as_ref(),
+            print,
+            &r.exclude,
+            r.use_structure_comparison,
         )?;
-        total_duplicates += type_duplicate_count;
     }
 
-    // Run overlap analysis if enabled
-    if overlap_enabled && (functions_enabled || types_enabled) {
+    if r.overlap && (functions_enabled || r.types_enabled) {
         println!("\n{separator}\n");
     }
 
-    if overlap_enabled {
+    if r.overlap {
         println!("=== Overlap Detection ===");
-        let overlap_duplicate_count = check_overlaps(
-            cli.paths,
-            cli.threshold,
-            cli.extensions.as_ref(),
-            cli.print,
-            cli.overlap_min_window,
-            cli.overlap_max_window,
-            cli.overlap_size_tolerance,
-            &cli.exclude,
+        total_duplicates += check_overlaps(
+            paths,
+            r.threshold,
+            r.extensions.as_ref(),
+            print,
+            r.overlap_min_window,
+            r.overlap_max_window,
+            r.overlap_size_tolerance,
+            &r.exclude,
         )?;
-        total_duplicates += overlap_duplicate_count;
     }
 
-    // Exit with code 1 if duplicates found and --fail-on-duplicates is set
-    if cli.fail_on_duplicates && total_duplicates > 0 {
+    if r.fail_on_duplicates && total_duplicates > 0 {
         std::process::exit(1);
     }
 
@@ -207,17 +115,15 @@ fn check_overlaps(
     let mut files = Vec::new();
     let mut visited = HashSet::new();
 
-    // Process each path
     for path_str in &paths {
         let path = Path::new(path_str);
 
         if path.is_file() {
-            // If it's a file, check extension and add it
             if let Some(ext) = path.extension() {
                 if let Some(ext_str) = ext.to_str() {
                     if exts.contains(&ext_str) {
                         if let Ok(canonical) = path.canonicalize() {
-                            if visited.insert(canonical.clone()) {
+                            if visited.insert(canonical) {
                                 files.push(path.to_path_buf());
                             }
                         }
@@ -225,32 +131,27 @@ fn check_overlaps(
                 }
             }
         } else if path.is_dir() {
-            // If it's a directory, walk it respecting .gitignore
             let walker = WalkBuilder::new(path).follow_links(false).build();
 
             for entry in walker {
                 let entry = entry?;
                 let entry_path = entry.path();
 
-                // Skip if not a file
                 if !entry_path.is_file() {
                     continue;
                 }
 
-                // Check if path should be excluded
                 if let Some(ref matcher) = exclude_matcher {
                     if matcher.is_match(entry_path) {
                         continue;
                     }
                 }
 
-                // Check extension
                 if let Some(ext) = entry_path.extension() {
                     if let Some(ext_str) = ext.to_str() {
                         if exts.contains(&ext_str) {
-                            // Get canonical path to avoid duplicates
                             if let Ok(canonical) = entry_path.canonicalize() {
-                                if visited.insert(canonical.clone()) {
+                                if visited.insert(canonical) {
                                     files.push(entry_path.to_path_buf());
                                 }
                             }
@@ -270,13 +171,11 @@ fn check_overlaps(
 
     println!("Checking {} files for overlapping code...\n", files.len());
 
-    // Read all file contents
     let mut file_contents = HashMap::new();
     for file in &files {
         match fs::read_to_string(file) {
             Ok(content) => {
-                let file_str = file.to_string_lossy().to_string();
-                file_contents.insert(file_str, content);
+                file_contents.insert(file.to_string_lossy().to_string(), content);
             }
             Err(e) => {
                 eprintln!("Error reading {}: {}", file.display(), e);
@@ -284,14 +183,10 @@ fn check_overlaps(
         }
     }
 
-    // Set up overlap options
     let options = OverlapOptions { min_window_size, max_window_size, threshold, size_tolerance };
-
-    // Create Rust parser
     let mut parser =
         RustParser::new().map_err(|e| anyhow::anyhow!("Failed to create Rust parser: {}", e))?;
 
-    // Find overlaps
     let overlaps = find_overlaps_across_files_generic(&mut parser, &file_contents, &options)
         .map_err(|e| anyhow::anyhow!("Failed to find overlaps: {}", e))?;
 
@@ -330,9 +225,9 @@ fn check_overlaps(
             );
 
             if print {
-                // Extract and display the overlapping code
                 if let Some(source_content) = file_contents.get(&overlap_with_files.source_file) {
-                    if let Some(target_content) = file_contents.get(&overlap_with_files.target_file)
+                    if let Some(target_content) =
+                        file_contents.get(&overlap_with_files.target_file)
                     {
                         println!("\n\x1b[36m--- Source Code ---\x1b[0m");
                         if let Ok(source_segment) = extract_code_lines(


### PR DESCRIPTION
## Context

I've been using `similarity-rs` in my workflow and found myself repeatedly typing the same flags on every run:

```bash
similarity-rs --threshold 0.90 --min-lines 5 --min-tokens 50 --skip-test --exclude "target/"
```

I wanted to persist those settings in the repo so the whole team uses the same thresholds without thinking about it — exactly like `rustfmt.toml` or `.clippy.toml`. There was no way to do that, so I built it.

---

## What this PR does

Place a `similarity.toml` at your project root (or anywhere up the directory tree) and `similarity-rs` will pick it up automatically:

```toml
# similarity.toml
threshold = 0.90
min_lines = 5
min_tokens = 50
skip_test = true
exclude = ["target/", "tests/fixtures/"]
```

**CLI flags always win** — the file is just a fallback, so one-off overrides still work as expected.

---

## Implementation

### `crates/core` — the reusable trait

Added a `ConfigLoader` trait with a full default implementation. Any binary gets config-file support by implementing a single empty `impl`:

```rust
pub trait ConfigLoader: Sized + Default + serde::de::DeserializeOwned {
    fn find_config_file() -> Option<PathBuf> { /* walks up from cwd */ }
    fn load_from_file(path: PathBuf) -> anyhow::Result<Self> { /* reads + parses toml */ }
    fn find_and_load() -> Self { /* find + load, falls back to Default */ }
}
```

### `crates/similarity-rs` — the concrete implementation

A `Config` struct mirrors every CLI flag (all `Option<T>`), implements the trait with zero methods, and is merged into a `ResolvedConfig` at startup:

```rust
#[derive(serde::Deserialize, Default)]
struct Config { threshold: Option<f64>, min_lines: Option<u32>, ... }

impl ConfigLoader for Config {}
```

Merge precedence: **CLI → config file → hardcoded default**.

### Tests

10 unit tests in `crates/core` covering file discovery (cwd, parent dir, missing), deserialization (full, partial, empty, invalid TOML), and the end-to-end `find_and_load` path.

---

## For other binaries (`similarity-ts`, `similarity-py`, ...)

The trait lives in core intentionally. Any other binary can adopt the same pattern by:

1. Adding `serde` to its dependencies
2. Defining a `Config` struct with `Option<T>` fields
3. Writing `impl ConfigLoader for Config {}`

No changes to the trait needed.

---

## Files changed

| File | Change |
|---|---|
| `crates/core/Cargo.toml` | `toml = "0.8"`, `tempfile` (dev) |
| `crates/core/src/config_loader.rs` | New — `ConfigLoader` trait + 10 tests |
| `crates/core/src/lib.rs` | Export `ConfigLoader` |
| `crates/similarity-rs/Cargo.toml` | `serde` dep |
| `crates/similarity-rs/src/config.rs` | New — `Cli`, `Config`, `ResolvedConfig` |
| `crates/similarity-rs/src/main.rs` | Now just parses + delegates to `config.rs` |
