### PR TITLE
Add ignore directives and config support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,6 +1370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1404,8 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
+ "toml",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
@@ -1527,6 +1538,7 @@ dependencies = [
  "ignore",
  "predicates",
  "rayon",
+ "serde",
  "similarity-core",
  "tempfile",
  "tree-sitter",
@@ -1763,6 +1775,47 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tree-sitter"
@@ -2176,6 +2229,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,6 +18,7 @@ oxc_span = { workspace = true }
 oxc_allocator = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.8"
 tree-sitter = { workspace = true }
 tree-sitter-go = { workspace = true }
 tree-sitter-java = { workspace = true }
@@ -31,6 +32,7 @@ anyhow = "1.0"
 
 [dev-dependencies]
 criterion = "0.5"
+tempfile = "3"
 
 [[bench]]
 name = "tsed_benchmark"

--- a/crates/core/src/class_extractor.rs
+++ b/crates/core/src/class_extractor.rs
@@ -3,6 +3,8 @@ use oxc_ast::ast::{ClassElement, MethodDefinitionKind, Statement};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
+use crate::ignore_directive::has_similarity_ignore_directive;
+
 #[derive(Debug, Clone)]
 pub struct ClassDefinition {
     pub name: String,
@@ -15,6 +17,7 @@ pub struct ClassDefinition {
     pub end_line: usize,
     pub file_path: String,
     pub is_abstract: bool,
+    pub has_ignore_directive: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -396,6 +399,7 @@ impl ClassExtractor {
             end_line,
             file_path: self.file_path.clone(),
             is_abstract: class.r#abstract,
+            has_ignore_directive: has_similarity_ignore_directive(&self.source_text, start_line),
         }
     }
 
@@ -459,4 +463,31 @@ pub fn extract_classes_from_files(files: &[(String, String)]) -> Vec<ClassDefini
     }
 
     all_classes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_classes_marks_similarity_ignore_directives() {
+        let source = r#"
+class ActiveService {
+    run(): void {}
+}
+
+// similarity-ignore
+class IgnoredService {
+    run(): void {}
+}
+"#;
+
+        let classes = extract_classes_from_code(source, "test.ts").unwrap();
+
+        let active = classes.iter().find(|class| class.name == "ActiveService").unwrap();
+        assert!(!active.has_ignore_directive);
+
+        let ignored = classes.iter().find(|class| class.name == "IgnoredService").unwrap();
+        assert!(ignored.has_ignore_directive);
+    }
 }

--- a/crates/core/src/config_loader.rs
+++ b/crates/core/src/config_loader.rs
@@ -1,0 +1,143 @@
+use std::path::PathBuf;
+
+pub trait ConfigLoader: Sized + Default + serde::de::DeserializeOwned {
+    fn find_config_file() -> Option<PathBuf> {
+        let mut dir = std::env::current_dir().ok()?;
+        loop {
+            let candidate = dir.join("similarity.toml");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+            if !dir.pop() {
+                return None;
+            }
+        }
+    }
+
+    fn load_from_file(path: PathBuf) -> anyhow::Result<Self> {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|error| anyhow::anyhow!("Failed to read {}: {}", path.display(), error))?;
+        let config = toml::from_str(&content)
+            .map_err(|error| anyhow::anyhow!("Failed to parse {}: {}", path.display(), error))?;
+        Ok(config)
+    }
+
+    fn find_and_load() -> Self {
+        let Some(path) = Self::find_config_file() else {
+            return Self::default();
+        };
+
+        Self::load_from_file(path.clone()).unwrap_or_else(|error| {
+            eprintln!("Warning: could not load {}: {error}", path.display());
+            Self::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+    fn cwd_lock() -> std::sync::MutexGuard<'static, ()> {
+        CWD_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[derive(Debug, Default, PartialEq, serde::Deserialize)]
+    struct TestConfig {
+        threshold: Option<f64>,
+        min_lines: Option<u32>,
+        skip_test: Option<bool>,
+        exclude: Option<Vec<String>>,
+    }
+
+    impl ConfigLoader for TestConfig {}
+
+    fn write_config(content: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("similarity.toml"), content).unwrap();
+        let path = dir.path().to_path_buf();
+        (dir, path)
+    }
+
+    #[test]
+    fn finds_config_in_current_dir() {
+        let _guard = cwd_lock();
+        let (_dir, dir_path) = write_config("threshold = 0.9");
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir_path).unwrap();
+
+        let found = TestConfig::find_config_file();
+
+        std::env::set_current_dir(original).unwrap();
+        assert!(found.is_some());
+    }
+
+    #[test]
+    fn finds_config_in_parent_dir() {
+        let _guard = cwd_lock();
+        let (_dir, dir_path) = write_config("threshold = 0.9");
+        let nested = dir_path.join("src/nested");
+        fs::create_dir_all(&nested).unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&nested).unwrap();
+
+        let found = TestConfig::find_config_file();
+
+        std::env::set_current_dir(original).unwrap();
+        assert_eq!(
+            found.and_then(|path| path.canonicalize().ok()),
+            Some(dir_path.join("similarity.toml").canonicalize().unwrap())
+        );
+    }
+
+    #[test]
+    fn returns_none_when_config_missing() {
+        let _guard = cwd_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let found = TestConfig::find_config_file();
+
+        std::env::set_current_dir(original).unwrap();
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn loads_partial_config() {
+        let (_dir, dir_path) = write_config("threshold = 0.75");
+
+        let config = TestConfig::load_from_file(dir_path.join("similarity.toml")).unwrap();
+
+        assert_eq!(
+            config,
+            TestConfig { threshold: Some(0.75), min_lines: None, skip_test: None, exclude: None }
+        );
+    }
+
+    #[test]
+    fn invalid_toml_returns_error() {
+        let (_dir, dir_path) = write_config("not = [valid");
+
+        let result = TestConfig::load_from_file(dir_path.join("similarity.toml"));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn find_and_load_falls_back_to_default() {
+        let _guard = cwd_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let config = TestConfig::find_and_load();
+
+        std::env::set_current_dir(original).unwrap();
+        assert_eq!(config, TestConfig::default());
+    }
+}

--- a/crates/core/src/fast_similarity.rs
+++ b/crates/core/src/fast_similarity.rs
@@ -41,7 +41,8 @@ pub fn find_similar_functions_fast(
     options: &FastSimilarityOptions,
 ) -> Result<Vec<SimilarityResult>, String> {
     // Extract functions
-    let functions = extract_functions(filename, source_text)?;
+    let mut functions = extract_functions(filename, source_text)?;
+    functions.retain(|function| !function.has_ignore_directive);
 
     // Create fingerprints
     let mut fingerprinted = Vec::new();
@@ -147,7 +148,8 @@ pub fn find_similar_functions_across_files_fast(
 
     // Extract functions with fingerprints from all files
     for (filename, source) in files {
-        let functions = extract_functions(filename, source)?;
+        let mut functions = extract_functions(filename, source)?;
+        functions.retain(|function| !function.has_ignore_directive);
         for func in functions {
             if let Some(min_tokens) = options.tsed_options.min_tokens {
                 // If min_tokens is specified, use token count instead of line count

--- a/crates/core/src/function_extractor.rs
+++ b/crates/core/src/function_extractor.rs
@@ -1,6 +1,7 @@
 use oxc_ast::ast::*;
 use oxc_span::Span;
 
+use crate::ignore_directive::has_similarity_ignore_directive;
 use crate::parser::parse_and_convert_to_tree;
 use crate::tsed::{calculate_tsed, TSEDOptions};
 
@@ -33,6 +34,7 @@ pub struct FunctionDefinition {
     pub class_name: Option<String>,
     pub parent_function: Option<String>,
     pub node_count: Option<u32>,
+    pub has_ignore_directive: bool,
 }
 
 impl FunctionDefinition {
@@ -117,16 +119,21 @@ fn extract_from_statement(stmt: &Statement, ctx: &mut ExtractionContext) {
             if let Some(name) = &func.id {
                 let func_name = name.name.to_string();
                 let params = extract_parameters(&func.params);
+                let start_line = get_line_number(func.span.start, ctx.source_text);
                 ctx.functions.push(FunctionDefinition {
                     name: func_name.clone(),
                     function_type: FunctionType::Function,
                     parameters: params,
                     body_span: func.span,
-                    start_line: get_line_number(func.span.start, ctx.source_text),
+                    start_line,
                     end_line: get_line_number(func.span.end, ctx.source_text),
                     class_name: None,
                     parent_function: ctx.parent_function.clone(),
                     node_count: count_function_nodes(func.span, ctx.source_text),
+                    has_ignore_directive: has_similarity_ignore_directive(
+                        ctx.source_text,
+                        start_line as usize,
+                    ),
                 });
 
                 // Extract nested functions within the function body
@@ -163,17 +170,22 @@ fn extract_from_statement(stmt: &Statement, ctx: &mut ExtractionContext) {
                     } else {
                         method_name.clone()
                     };
+                    let start_line = get_line_number(method.span.start, ctx.source_text);
 
                     ctx.functions.push(FunctionDefinition {
                         name: method_name.clone(),
                         function_type,
                         parameters: params,
                         body_span: method.span,
-                        start_line: get_line_number(method.span.start, ctx.source_text),
+                        start_line,
                         end_line: get_line_number(method.span.end, ctx.source_text),
                         class_name: class_name.clone(),
                         parent_function: ctx.parent_function.clone(),
                         node_count: count_function_nodes(method.span, ctx.source_text),
+                        has_ignore_directive: has_similarity_ignore_directive(
+                            ctx.source_text,
+                            start_line as usize,
+                        ),
                     });
 
                     // Extract nested functions within method body
@@ -194,16 +206,21 @@ fn extract_from_statement(stmt: &Statement, ctx: &mut ExtractionContext) {
                     if let BindingPatternKind::BindingIdentifier(ident) = &decl.id.kind {
                         let params = extract_parameters(&arrow.params);
                         let arrow_name = ident.name.to_string();
+                        let start_line = get_line_number(arrow.span.start, ctx.source_text);
                         ctx.functions.push(FunctionDefinition {
                             name: arrow_name.clone(),
                             function_type: FunctionType::Arrow,
                             parameters: params,
                             body_span: arrow.span,
-                            start_line: get_line_number(arrow.span.start, ctx.source_text),
+                            start_line,
                             end_line: get_line_number(arrow.span.end, ctx.source_text),
                             class_name: None,
                             parent_function: ctx.parent_function.clone(),
                             node_count: count_function_nodes(arrow.span, ctx.source_text),
+                            has_ignore_directive: has_similarity_ignore_directive(
+                                ctx.source_text,
+                                start_line as usize,
+                            ),
                         });
 
                         // Extract nested functions within arrow function body
@@ -231,16 +248,21 @@ fn extract_from_statement(stmt: &Statement, ctx: &mut ExtractionContext) {
                     .unwrap_or_else(|| "default".to_string());
                 let params = extract_parameters(&func.params);
                 let func_name = name.clone();
+                let start_line = get_line_number(func.span.start, ctx.source_text);
                 ctx.functions.push(FunctionDefinition {
                     name: func_name.clone(),
                     function_type: FunctionType::Function,
                     parameters: params,
                     body_span: func.span,
-                    start_line: get_line_number(func.span.start, ctx.source_text),
+                    start_line,
                     end_line: get_line_number(func.span.end, ctx.source_text),
                     class_name: None,
                     parent_function: ctx.parent_function.clone(),
                     node_count: count_function_nodes(func.span, ctx.source_text),
+                    has_ignore_directive: has_similarity_ignore_directive(
+                        ctx.source_text,
+                        start_line as usize,
+                    ),
                 });
 
                 // Extract nested functions within the function body
@@ -262,16 +284,21 @@ fn extract_from_declaration(decl: &Declaration, ctx: &mut ExtractionContext) {
             if let Some(name) = &func.id {
                 let func_name = name.name.to_string();
                 let params = extract_parameters(&func.params);
+                let start_line = get_line_number(func.span.start, ctx.source_text);
                 ctx.functions.push(FunctionDefinition {
                     name: func_name.clone(),
                     function_type: FunctionType::Function,
                     parameters: params,
                     body_span: func.span,
-                    start_line: get_line_number(func.span.start, ctx.source_text),
+                    start_line,
                     end_line: get_line_number(func.span.end, ctx.source_text),
                     class_name: None,
                     parent_function: ctx.parent_function.clone(),
                     node_count: count_function_nodes(func.span, ctx.source_text),
+                    has_ignore_directive: has_similarity_ignore_directive(
+                        ctx.source_text,
+                        start_line as usize,
+                    ),
                 });
 
                 // Extract nested functions within the function body
@@ -308,17 +335,22 @@ fn extract_from_declaration(decl: &Declaration, ctx: &mut ExtractionContext) {
                     } else {
                         method_name.clone()
                     };
+                    let start_line = get_line_number(method.span.start, ctx.source_text);
 
                     ctx.functions.push(FunctionDefinition {
                         name: method_name.clone(),
                         function_type,
                         parameters: params,
                         body_span: method.span,
-                        start_line: get_line_number(method.span.start, ctx.source_text),
+                        start_line,
                         end_line: get_line_number(method.span.end, ctx.source_text),
                         class_name: class_name.clone(),
                         parent_function: ctx.parent_function.clone(),
                         node_count: count_function_nodes(method.span, ctx.source_text),
+                        has_ignore_directive: has_similarity_ignore_directive(
+                            ctx.source_text,
+                            start_line as usize,
+                        ),
                     });
 
                     // Extract nested functions within method body
@@ -339,16 +371,21 @@ fn extract_from_declaration(decl: &Declaration, ctx: &mut ExtractionContext) {
                     if let BindingPatternKind::BindingIdentifier(ident) = &decl.id.kind {
                         let params = extract_parameters(&arrow.params);
                         let arrow_name = ident.name.to_string();
+                        let start_line = get_line_number(arrow.span.start, ctx.source_text);
                         ctx.functions.push(FunctionDefinition {
                             name: arrow_name.clone(),
                             function_type: FunctionType::Arrow,
                             parameters: params,
                             body_span: arrow.span,
-                            start_line: get_line_number(arrow.span.start, ctx.source_text),
+                            start_line,
                             end_line: get_line_number(arrow.span.end, ctx.source_text),
                             class_name: None,
                             parent_function: ctx.parent_function.clone(),
                             node_count: count_function_nodes(arrow.span, ctx.source_text),
+                            has_ignore_directive: has_similarity_ignore_directive(
+                                ctx.source_text,
+                                start_line as usize,
+                            ),
                         });
 
                         // Extract nested functions within arrow function body
@@ -503,7 +540,8 @@ pub fn find_similar_functions_in_file(
     threshold: f64,
     options: &TSEDOptions,
 ) -> Result<Vec<SimilarityResult>, String> {
-    let functions = extract_functions(filename, source_text)?;
+    let mut functions = extract_functions(filename, source_text)?;
+    functions.retain(|function| !function.has_ignore_directive);
     let mut similar_pairs = Vec::new();
 
     // Compare all pairs
@@ -564,7 +602,8 @@ pub fn find_similar_functions_across_files(
 
     // Extract functions from all files
     for (filename, source) in files {
-        let functions = extract_functions(filename, source)?;
+        let mut functions = extract_functions(filename, source)?;
+        functions.retain(|function| !function.has_ignore_directive);
         for func in functions {
             all_functions.push((filename.clone(), source.clone(), func));
         }
@@ -831,5 +870,38 @@ mod tests {
                 || (result.func1.name == "checkUser" && result.func2.name == "validateUser")
         });
         assert!(validate_check.is_some());
+    }
+
+    #[test]
+    fn test_extract_functions_marks_similarity_ignore_directives() {
+        let code = r#"
+function keepMe() {
+    return 1;
+}
+
+// similarity-ignore
+function ignoreMe() {
+    return 2;
+}
+
+/**
+ * Keep this duplicated export local for now.
+ */
+// similarity-ignore
+export function ignoredExport() {
+    return 3;
+}
+"#;
+
+        let functions = extract_functions("test.ts", code).unwrap();
+
+        let keep = functions.iter().find(|f| f.name == "keepMe").unwrap();
+        assert!(!keep.has_ignore_directive);
+
+        let ignored = functions.iter().find(|f| f.name == "ignoreMe").unwrap();
+        assert!(ignored.has_ignore_directive);
+
+        let ignored_export = functions.iter().find(|f| f.name == "ignoredExport").unwrap();
+        assert!(ignored_export.has_ignore_directive);
     }
 }

--- a/crates/core/src/ignore_directive.rs
+++ b/crates/core/src/ignore_directive.rs
@@ -1,0 +1,104 @@
+pub(crate) fn has_similarity_ignore_directive(source_text: &str, start_line: usize) -> bool {
+    if start_line <= 1 {
+        return false;
+    }
+
+    let lines: Vec<&str> = source_text.lines().collect();
+    if start_line > lines.len() + 1 {
+        return false;
+    }
+
+    let mut current = start_line - 1;
+    let mut in_block_comment = false;
+
+    while current > 0 {
+        current -= 1;
+        let line = lines[current].trim();
+
+        if line.is_empty() {
+            continue;
+        }
+
+        if in_block_comment {
+            if line.contains("similarity-ignore") {
+                return true;
+            }
+            if line.starts_with("/*") || line.contains("/*") {
+                in_block_comment = false;
+            }
+            continue;
+        }
+
+        if line.starts_with("//") {
+            if line.contains("similarity-ignore") {
+                return true;
+            }
+            continue;
+        }
+
+        if line.starts_with("/*") {
+            return line.contains("similarity-ignore");
+        }
+
+        if line.ends_with("*/") || line.starts_with("*/") {
+            if line.contains("similarity-ignore") {
+                return true;
+            }
+            if !line.contains("/*") {
+                in_block_comment = true;
+            }
+            continue;
+        }
+
+        if line.starts_with('*') {
+            if line.contains("similarity-ignore") {
+                return true;
+            }
+            continue;
+        }
+
+        break;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_similarity_ignore_directive;
+
+    #[test]
+    fn detects_single_line_directive() {
+        let source = r#"
+// similarity-ignore
+function test() {}
+"#;
+
+        assert!(has_similarity_ignore_directive(source, 3));
+    }
+
+    #[test]
+    fn detects_block_comment_directive() {
+        let source = r#"
+/**
+ * similarity-ignore
+ */
+function test() {}
+"#;
+
+        assert!(has_similarity_ignore_directive(source, 5));
+    }
+
+    #[test]
+    fn stops_at_non_comment_code() {
+        let source = r#"
+const marker = true;
+// similarity-ignore
+
+function test() {}
+"#;
+
+        assert!(has_similarity_ignore_directive(source, 5));
+        assert!(!has_similarity_ignore_directive(source, 2));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ast_exchange;
 pub mod ast_fingerprint;
 pub mod class_comparator;
 pub mod class_extractor;
+pub mod config_loader;
 pub mod css_structure_adapter;
 pub mod enhanced_similarity;
 pub mod fast_similarity;
@@ -12,6 +13,7 @@ pub mod function_extractor;
 pub mod generic_overlap_detector;
 pub mod generic_parser_config;
 pub mod generic_tree_sitter_parser;
+mod ignore_directive;
 pub mod language_parser;
 pub mod overlap_detector;
 pub mod parser;
@@ -114,6 +116,7 @@ pub use class_extractor::{
     extract_classes_from_code, extract_classes_from_files, ClassDefinition, ClassMethod,
     ClassProperty, MethodKind,
 };
+pub use config_loader::ConfigLoader;
 
 #[cfg(test)]
 mod structure_comparator_tests;

--- a/crates/core/src/structure_comparator_tests.rs
+++ b/crates/core/src/structure_comparator_tests.rs
@@ -128,6 +128,7 @@ mod tests {
             start_line: 1,
             end_line: 5,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         };
 
         let type2 = TypeDefinition {
@@ -144,6 +145,7 @@ mod tests {
             start_line: 10,
             end_line: 15,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         };
 
         let result = comparator.compare_types(&type1, &type2);

--- a/crates/core/src/type_comparator.rs
+++ b/crates/core/src/type_comparator.rs
@@ -378,6 +378,7 @@ pub fn compare_type_literal_with_type(
         start_line: type_literal.start_line,
         end_line: type_literal.end_line,
         file_path: type_literal.file_path.clone(),
+        has_ignore_directive: false,
     };
 
     compare_types(&temp_type_def, type_definition, options)
@@ -456,6 +457,7 @@ pub fn find_similar_type_literals_pairs(
                     start_line: type_literal2.start_line,
                     end_line: type_literal2.end_line,
                     file_path: type_literal2.file_path.clone(),
+                    has_ignore_directive: false,
                 },
                 options,
             );
@@ -495,6 +497,7 @@ mod tests {
             start_line: 1,
             end_line: 10,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         }
     }
 

--- a/crates/core/src/type_extractor.rs
+++ b/crates/core/src/type_extractor.rs
@@ -7,6 +7,8 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use std::collections::HashMap;
 
+use crate::ignore_directive::has_similarity_ignore_directive;
+
 #[derive(Debug, Clone)]
 pub struct TypeDefinition {
     pub name: String,
@@ -17,6 +19,7 @@ pub struct TypeDefinition {
     pub start_line: usize,
     pub end_line: usize,
     pub file_path: String,
+    pub has_ignore_directive: bool,
 }
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeKind {
@@ -106,6 +109,23 @@ impl TypeExtractor {
                         types.push(type_def);
                     }
                 }
+                Statement::ExportNamedDeclaration(export) => {
+                    if let Some(decl) = &export.declaration {
+                        match decl {
+                            oxc_ast::ast::Declaration::TSInterfaceDeclaration(interface) => {
+                                if let Some(type_def) = self.extract_interface(interface) {
+                                    types.push(type_def);
+                                }
+                            }
+                            oxc_ast::ast::Declaration::TSTypeAliasDeclaration(type_alias) => {
+                                if let Some(type_def) = self.extract_type_alias(type_alias) {
+                                    types.push(type_def);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
                 _ => {}
             }
         }
@@ -152,6 +172,7 @@ impl TypeExtractor {
             start_line,
             end_line,
             file_path: self.file_path.clone(),
+            has_ignore_directive: has_similarity_ignore_directive(&self.source_text, start_line),
         })
     }
 
@@ -172,6 +193,7 @@ impl TypeExtractor {
             start_line,
             end_line,
             file_path: self.file_path.clone(),
+            has_ignore_directive: has_similarity_ignore_directive(&self.source_text, start_line),
         })
     }
 
@@ -659,5 +681,35 @@ interface User extends BaseUser {
         let user_type = &types[1];
         assert_eq!(user_type.name, "User");
         assert_eq!(user_type.extends, vec!["BaseUser"]);
+    }
+
+    #[test]
+    fn test_extract_types_marks_similarity_ignore_directives() {
+        let source = r#"
+// similarity-ignore
+interface IgnoredUser {
+    id: string;
+}
+
+type ActiveUser = {
+    id: string;
+};
+
+/* similarity-ignore */
+type IgnoredAlias = {
+    value: number;
+};
+"#;
+
+        let types = extract_types_from_code(source, "test.ts").unwrap();
+
+        let ignored_user = types.iter().find(|t| t.name == "IgnoredUser").unwrap();
+        assert!(ignored_user.has_ignore_directive);
+
+        let active_user = types.iter().find(|t| t.name == "ActiveUser").unwrap();
+        assert!(!active_user.has_ignore_directive);
+
+        let ignored_alias = types.iter().find(|t| t.name == "IgnoredAlias").unwrap();
+        assert!(ignored_alias.has_ignore_directive);
     }
 }

--- a/crates/core/src/type_fingerprint.rs
+++ b/crates/core/src/type_fingerprint.rs
@@ -206,6 +206,7 @@ mod tests {
             start_line: 1,
             end_line: 5,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         };
 
         let fingerprint = generate_type_fingerprint(&type_def);

--- a/crates/core/src/type_normalizer.rs
+++ b/crates/core/src/type_normalizer.rs
@@ -445,6 +445,7 @@ mod tests {
             start_line: 1,
             end_line: 10,
             file_path: "test.ts".to_string(),
+            has_ignore_directive: false,
         }
     }
 

--- a/crates/core/src/typescript_structure_adapter.rs
+++ b/crates/core/src/typescript_structure_adapter.rs
@@ -344,6 +344,7 @@ mod tests {
             start_line: 1,
             end_line: 5,
             file_path: "user.ts".to_string(),
+            has_ignore_directive: false,
         };
 
         let structure = Structure::from(type_def);
@@ -380,6 +381,7 @@ mod tests {
             start_line: 1,
             end_line: 5,
             file_path: "user.ts".to_string(),
+            has_ignore_directive: false,
         };
 
         let type2 = TypeDefinition {
@@ -404,6 +406,7 @@ mod tests {
             start_line: 10,
             end_line: 15,
             file_path: "person.ts".to_string(),
+            has_ignore_directive: false,
         };
 
         let result = comparator.compare_types(&type1, &type2);

--- a/crates/core/src/unified_type_comparator.rs
+++ b/crates/core/src/unified_type_comparator.rs
@@ -94,6 +94,7 @@ fn type_literal_to_type_def(literal: &TypeLiteralDefinition) -> TypeDefinition {
         start_line: literal.start_line,
         end_line: literal.end_line,
         file_path: literal.file_path.clone(),
+        has_ignore_directive: false,
     }
 }
 

--- a/crates/similarity-rs/Cargo.toml
+++ b/crates/similarity-rs/Cargo.toml
@@ -21,6 +21,7 @@ name = "similarity_rs"
 [dependencies]
 similarity-core = { version = "0.4.2", path = "../core" }
 clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 rayon = "1.10"
 ignore = "0.4"

--- a/crates/similarity-rs/src/config.rs
+++ b/crates/similarity-rs/src/config.rs
@@ -1,0 +1,191 @@
+use clap::Parser;
+use similarity_core::ConfigLoader;
+
+#[derive(Debug, Parser)]
+#[command(name = "similarity-rs")]
+#[command(about = "Rust code similarity analyzer")]
+#[command(version)]
+pub struct Cli {
+    /// Paths to analyze (files or directories)
+    #[arg(default_value = ".")]
+    pub paths: Vec<String>,
+
+    /// Print code in output
+    #[arg(short, long)]
+    pub print: bool,
+
+    /// Similarity threshold (0.0-1.0)
+    #[arg(short, long)]
+    pub threshold: Option<f64>,
+
+    /// File extensions to check
+    #[arg(short, long, value_delimiter = ',')]
+    pub extensions: Option<Vec<String>>,
+
+    /// Minimum lines for functions to be considered
+    #[arg(short, long)]
+    pub min_lines: Option<u32>,
+
+    /// Minimum tokens for functions to be considered
+    #[arg(long)]
+    pub min_tokens: Option<u32>,
+
+    /// Rename cost for APTED algorithm
+    #[arg(short, long)]
+    pub rename_cost: Option<f64>,
+
+    /// Disable size penalty for very different sized functions
+    #[arg(long)]
+    pub no_size_penalty: bool,
+
+    /// Filter functions by name (substring match)
+    #[arg(long)]
+    pub filter_function: Option<String>,
+
+    /// Filter functions by body content (substring match)
+    #[arg(long)]
+    pub filter_function_body: Option<String>,
+
+    /// Disable fast mode with bloom filter pre-filtering
+    #[arg(long)]
+    pub no_fast: bool,
+
+    /// Exclude directories matching the given patterns (can be specified multiple times)
+    #[arg(long)]
+    pub exclude: Vec<String>,
+
+    /// Skip test functions (functions starting with 'test_' or annotated with #[test])
+    #[arg(long)]
+    pub skip_test: bool,
+
+    /// Enable experimental overlap detection mode
+    #[arg(long = "experimental-overlap")]
+    pub overlap: bool,
+
+    /// Minimum window size for overlap detection (number of nodes)
+    #[arg(long)]
+    pub overlap_min_window: Option<u32>,
+
+    /// Maximum window size for overlap detection (number of nodes)
+    #[arg(long)]
+    pub overlap_max_window: Option<u32>,
+
+    /// Size tolerance for overlap detection (0.0-1.0)
+    #[arg(long)]
+    pub overlap_size_tolerance: Option<f64>,
+
+    /// Exit with code 1 if duplicates are found
+    #[arg(long)]
+    pub fail_on_duplicates: bool,
+
+    /// Enable type similarity checking for structs and enums (experimental)
+    #[arg(long = "experimental-types")]
+    pub types: bool,
+
+    /// Disable function similarity checking
+    #[arg(long = "no-functions")]
+    pub no_functions: bool,
+
+    /// Use new generalized structure comparison framework (experimental)
+    #[arg(long)]
+    pub use_structure_comparison: bool,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct Config {
+    pub threshold: Option<f64>,
+    pub extensions: Option<Vec<String>>,
+    pub min_lines: Option<u32>,
+    pub min_tokens: Option<u32>,
+    pub rename_cost: Option<f64>,
+    pub no_size_penalty: Option<bool>,
+    pub filter_function: Option<String>,
+    pub filter_function_body: Option<String>,
+    pub no_fast: Option<bool>,
+    pub exclude: Option<Vec<String>>,
+    pub skip_test: Option<bool>,
+    pub overlap: Option<bool>,
+    pub overlap_min_window: Option<u32>,
+    pub overlap_max_window: Option<u32>,
+    pub overlap_size_tolerance: Option<f64>,
+    pub fail_on_duplicates: Option<bool>,
+    pub types: Option<bool>,
+    pub no_functions: Option<bool>,
+    pub use_structure_comparison: Option<bool>,
+}
+
+impl ConfigLoader for Config {}
+
+pub struct ResolvedConfig {
+    pub threshold: f64,
+    pub extensions: Option<Vec<String>>,
+    pub min_lines: u32,
+    pub min_tokens: Option<u32>,
+    pub rename_cost: f64,
+    pub no_size_penalty: bool,
+    pub filter_function: Option<String>,
+    pub filter_function_body: Option<String>,
+    pub no_fast: bool,
+    pub exclude: Vec<String>,
+    pub skip_test: bool,
+    pub overlap: bool,
+    pub overlap_min_window: u32,
+    pub overlap_max_window: u32,
+    pub overlap_size_tolerance: f64,
+    pub fail_on_duplicates: bool,
+    pub types: bool,
+    pub no_functions: bool,
+    pub use_structure_comparison: bool,
+}
+
+fn resolve_value<T>(cli: Option<T>, config: Option<T>, default: T) -> T {
+    cli.or(config).unwrap_or(default)
+}
+
+fn resolve_option<T>(cli: Option<T>, config: Option<T>, default: Option<T>) -> Option<T> {
+    cli.or(config).or(default)
+}
+
+fn resolve_flag(cli: bool, config: Option<bool>) -> bool {
+    cli || config.unwrap_or(false)
+}
+
+impl ResolvedConfig {
+    pub fn from(cli: Cli, config: Config) -> Self {
+        let mut exclude = config.exclude.unwrap_or_default();
+        exclude.extend(cli.exclude);
+
+        Self {
+            threshold: resolve_value(cli.threshold, config.threshold, 0.85),
+            extensions: cli.extensions.or(config.extensions),
+            min_lines: resolve_value(cli.min_lines, config.min_lines, 3),
+            min_tokens: resolve_option(cli.min_tokens, config.min_tokens, Some(30)),
+            rename_cost: resolve_value(cli.rename_cost, config.rename_cost, 0.3),
+            no_size_penalty: resolve_flag(cli.no_size_penalty, config.no_size_penalty),
+            filter_function: cli.filter_function.or(config.filter_function),
+            filter_function_body: cli.filter_function_body.or(config.filter_function_body),
+            no_fast: resolve_flag(cli.no_fast, config.no_fast),
+            exclude,
+            skip_test: resolve_flag(cli.skip_test, config.skip_test),
+            overlap: resolve_flag(cli.overlap, config.overlap),
+            overlap_min_window: resolve_value(cli.overlap_min_window, config.overlap_min_window, 8),
+            overlap_max_window: resolve_value(
+                cli.overlap_max_window,
+                config.overlap_max_window,
+                25,
+            ),
+            overlap_size_tolerance: resolve_value(
+                cli.overlap_size_tolerance,
+                config.overlap_size_tolerance,
+                0.25,
+            ),
+            fail_on_duplicates: resolve_flag(cli.fail_on_duplicates, config.fail_on_duplicates),
+            types: resolve_flag(cli.types, config.types),
+            no_functions: resolve_flag(cli.no_functions, config.no_functions),
+            use_structure_comparison: resolve_flag(
+                cli.use_structure_comparison,
+                config.use_structure_comparison,
+            ),
+        }
+    }
+}

--- a/crates/similarity-rs/src/main.rs
+++ b/crates/similarity-rs/src/main.rs
@@ -1,107 +1,25 @@
 use anyhow::Result;
 use clap::Parser;
+use similarity_core::ConfigLoader;
 
 mod check;
 mod check_types;
+mod config;
 mod parallel;
 mod rust_parser;
 
-#[derive(Parser)]
-#[command(name = "similarity-rs")]
-#[command(about = "Rust code similarity analyzer")]
-#[command(version)]
-struct Cli {
-    /// Paths to analyze (files or directories)
-    #[arg(default_value = ".")]
-    paths: Vec<String>,
-
-    /// Print code in output
-    #[arg(short, long)]
-    print: bool,
-
-    /// Similarity threshold (0.0-1.0)
-    #[arg(short, long, default_value = "0.85")]
-    threshold: f64,
-
-    /// File extensions to check
-    #[arg(short, long, value_delimiter = ',')]
-    extensions: Option<Vec<String>>,
-
-    /// Minimum lines for functions to be considered
-    #[arg(short, long, default_value = "3")]
-    min_lines: Option<u32>,
-
-    /// Minimum tokens for functions to be considered
-    #[arg(long, default_value = "30")]
-    min_tokens: Option<u32>,
-
-    /// Rename cost for APTED algorithm
-    #[arg(short, long, default_value = "0.3")]
-    rename_cost: f64,
-
-    /// Disable size penalty for very different sized functions
-    #[arg(long)]
-    no_size_penalty: bool,
-
-    /// Filter functions by name (substring match)
-    #[arg(long)]
-    filter_function: Option<String>,
-
-    /// Filter functions by body content (substring match)
-    #[arg(long)]
-    filter_function_body: Option<String>,
-
-    /// Disable fast mode with bloom filter pre-filtering
-    #[arg(long)]
-    no_fast: bool,
-
-    /// Exclude directories matching the given patterns (can be specified multiple times)
-    #[arg(long)]
-    exclude: Vec<String>,
-
-    /// Skip test functions (functions starting with 'test_' or annotated with #[test])
-    #[arg(long)]
-    skip_test: bool,
-
-    /// Enable experimental overlap detection mode
-    #[arg(long = "experimental-overlap")]
-    overlap: bool,
-
-    /// Minimum window size for overlap detection (number of nodes)
-    #[arg(long, default_value = "8")]
-    overlap_min_window: u32,
-
-    /// Maximum window size for overlap detection (number of nodes)
-    #[arg(long, default_value = "25")]
-    overlap_max_window: u32,
-
-    /// Size tolerance for overlap detection (0.0-1.0)
-    #[arg(long, default_value = "0.25")]
-    overlap_size_tolerance: f64,
-
-    /// Exit with code 1 if duplicates are found
-    #[arg(long)]
-    fail_on_duplicates: bool,
-
-    /// Enable type similarity checking for structs and enums (experimental)
-    #[arg(long = "experimental-types")]
-    types: bool,
-
-    /// Disable function similarity checking
-    #[arg(long = "no-functions")]
-    no_functions: bool,
-
-    /// Use new generalized structure comparison framework (experimental)
-    #[arg(long)]
-    use_structure_comparison: bool,
-}
+use config::{Cli, Config, ResolvedConfig};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    let paths = cli.paths.clone();
+    let print = cli.print;
+    let config = Config::find_and_load();
+    let resolved = ResolvedConfig::from(cli, config);
 
-    let functions_enabled = !cli.no_functions;
-    let types_enabled = cli.types;
-    let overlap_enabled = cli.overlap;
+    let functions_enabled = !resolved.no_functions;
+    let types_enabled = resolved.types;
+    let overlap_enabled = resolved.overlap;
 
     // Validate that at least one analyzer is enabled
     if !functions_enabled && !types_enabled && !overlap_enabled {
@@ -118,19 +36,19 @@ fn main() -> Result<()> {
     if functions_enabled {
         println!("=== Function Similarity ===");
         let duplicate_count = check::check_paths(
-            cli.paths.clone(),
-            cli.threshold,
-            cli.rename_cost,
-            cli.extensions.as_ref(),
-            cli.min_lines.unwrap_or(3),
-            cli.min_tokens,
-            cli.no_size_penalty,
-            cli.print,
-            !cli.no_fast,
-            cli.filter_function.as_ref(),
-            cli.filter_function_body.as_ref(),
-            &cli.exclude,
-            cli.skip_test,
+            paths.clone(),
+            resolved.threshold,
+            resolved.rename_cost,
+            resolved.extensions.as_ref(),
+            resolved.min_lines,
+            resolved.min_tokens,
+            resolved.no_size_penalty,
+            print,
+            !resolved.no_fast,
+            resolved.filter_function.as_ref(),
+            resolved.filter_function_body.as_ref(),
+            &resolved.exclude,
+            resolved.skip_test,
         )?;
         total_duplicates += duplicate_count;
     }
@@ -143,12 +61,12 @@ fn main() -> Result<()> {
     if types_enabled {
         println!("=== Type Similarity (Structs & Enums) ===");
         let type_duplicate_count = check_types::check_types(
-            cli.paths.clone(),
-            cli.threshold,
-            cli.extensions.as_ref(),
-            cli.print,
-            &cli.exclude,
-            cli.use_structure_comparison,
+            paths.clone(),
+            resolved.threshold,
+            resolved.extensions.as_ref(),
+            print,
+            &resolved.exclude,
+            resolved.use_structure_comparison,
         )?;
         total_duplicates += type_duplicate_count;
     }
@@ -161,20 +79,20 @@ fn main() -> Result<()> {
     if overlap_enabled {
         println!("=== Overlap Detection ===");
         let overlap_duplicate_count = check_overlaps(
-            cli.paths,
-            cli.threshold,
-            cli.extensions.as_ref(),
-            cli.print,
-            cli.overlap_min_window,
-            cli.overlap_max_window,
-            cli.overlap_size_tolerance,
-            &cli.exclude,
+            paths,
+            resolved.threshold,
+            resolved.extensions.as_ref(),
+            print,
+            resolved.overlap_min_window,
+            resolved.overlap_max_window,
+            resolved.overlap_size_tolerance,
+            &resolved.exclude,
         )?;
         total_duplicates += overlap_duplicate_count;
     }
 
     // Exit with code 1 if duplicates found and --fail-on-duplicates is set
-    if cli.fail_on_duplicates && total_duplicates > 0 {
+    if resolved.fail_on_duplicates && total_duplicates > 0 {
         std::process::exit(1);
     }
 

--- a/crates/similarity-rs/tests/config_file_test.rs
+++ b/crates/similarity-rs/tests/config_file_test.rs
@@ -1,0 +1,87 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn test_similarity_toml_supplies_default_options() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("sample.rs");
+
+    fs::write(
+        dir.path().join("similarity.toml"),
+        r#"
+threshold = 0.7
+min_tokens = 1
+no_size_penalty = true
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        &file,
+        r#"
+fn add_one(x: i32) -> i32 {
+    let value = x + 1;
+    value
+}
+
+fn increment(y: i32) -> i32 {
+    let result = y + 1;
+    result
+}
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("similarity-rs")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg(".")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("add_one"))
+        .stdout(predicate::str::contains("increment"));
+}
+
+#[test]
+fn test_cli_flags_override_similarity_toml() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("sample.rs");
+
+    fs::write(
+        dir.path().join("similarity.toml"),
+        r#"
+threshold = 0.7
+min_tokens = 1
+no_size_penalty = true
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        &file,
+        r#"
+fn add_one(x: i32) -> i32 {
+    let value = x + 1;
+    value
+}
+
+fn increment(y: i32) -> i32 {
+    let result = y + 1;
+    result
+}
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("similarity-rs")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg(".")
+        .arg("--min-tokens")
+        .arg("30")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No duplicate functions found!"));
+}

--- a/crates/similarity-ts/src/check.rs
+++ b/crates/similarity-ts/src/check.rs
@@ -5,7 +5,7 @@ use crate::parallel::{
     load_files_parallel,
 };
 use ignore::WalkBuilder;
-use similarity_core::TSEDOptions;
+use similarity_core::{extract_functions, TSEDOptions};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -267,6 +267,7 @@ pub fn check_paths(
     filter_function: Option<&String>,
     filter_function_body: Option<&String>,
     exclude_patterns: &[String],
+    show_ignored: bool,
 ) -> anyhow::Result<usize> {
     let default_extensions = vec!["ts", "tsx", "js", "jsx", "mjs", "cjs", "mts", "cts"];
     let exts: Vec<&str> =
@@ -394,5 +395,39 @@ pub fn check_paths(
     let duplicate_count =
         display_all_results(all_results, print, filter_function, filter_function_body);
 
+    if show_ignored {
+        report_ignored_functions(&files);
+    }
+
     Ok(duplicate_count)
+}
+
+fn report_ignored_functions(files: &[PathBuf]) {
+    let mut ignored = Vec::new();
+
+    for file in files {
+        let Ok(content) = fs::read_to_string(file) else {
+            continue;
+        };
+        let filename = file.to_string_lossy();
+        let Ok(functions) = extract_functions(&filename, &content) else {
+            continue;
+        };
+
+        ignored.extend(
+            functions
+                .into_iter()
+                .filter(|function| function.has_ignore_directive)
+                .map(|function| (file.display().to_string(), function.name, function.start_line)),
+        );
+    }
+
+    if ignored.is_empty() {
+        return;
+    }
+
+    println!("Ignored {} function(s) via similarity-ignore directive:", ignored.len());
+    for (file, name, line) in ignored {
+        println!("  {}:{} {}", file, line, name);
+    }
 }

--- a/crates/similarity-ts/src/main.rs
+++ b/crates/similarity-ts/src/main.rs
@@ -82,6 +82,10 @@ struct Cli {
     #[arg(long)]
     filter_function_body: Option<String>,
 
+    /// Show functions, types, and classes ignored via similarity-ignore comments
+    #[arg(long)]
+    show_ignored: bool,
+
     /// Include both interfaces and type aliases (deprecated - both are included by default)
     #[arg(long, hide = true)]
     include_types: bool,
@@ -200,6 +204,7 @@ fn main() -> anyhow::Result<()> {
             cli.filter_function.as_ref(),
             cli.filter_function_body.as_ref(),
             &cli.exclude,
+            cli.show_ignored,
         )?;
         total_duplicates += duplicate_count;
     }
@@ -226,6 +231,7 @@ fn main() -> anyhow::Result<()> {
             unified_types_enabled,
             &cli.exclude,
             cli.use_structure_comparison,
+            cli.show_ignored,
         )?;
         total_duplicates += type_duplicate_count;
     }
@@ -246,6 +252,7 @@ fn main() -> anyhow::Result<()> {
             !cli.include_implements,
             cli.suggest,
             &cli.exclude,
+            cli.show_ignored,
         )?;
         total_duplicates += class_duplicate_count;
     }
@@ -331,6 +338,7 @@ fn check_types(
     unified_types: bool,
     exclude_patterns: &[String],
     use_structure_comparison: bool,
+    show_ignored: bool,
 ) -> anyhow::Result<usize> {
     use ignore::WalkBuilder;
     use similarity_core::{
@@ -431,6 +439,7 @@ fn check_types(
     // Extract types from all files
     let mut all_types = Vec::new();
     let mut all_type_literals = Vec::new();
+    let mut ignored_types = Vec::new();
 
     for file in &files {
         match fs::read_to_string(file) {
@@ -441,6 +450,15 @@ fn check_types(
                 if !type_literals_only {
                     match extract_types_from_code(&content, &file_str) {
                         Ok(mut types) => {
+                            if show_ignored {
+                                ignored_types.extend(
+                                    types.iter().filter(|ty| ty.has_ignore_directive).map(|ty| {
+                                        (file.display().to_string(), ty.name.clone(), ty.start_line)
+                                    }),
+                                );
+                            }
+                            types.retain(|ty| !ty.has_ignore_directive);
+
                             // Filter types based on command line options
                             if types_only {
                                 types.retain(|t| t.kind == TypeKind::TypeAlias);
@@ -487,6 +505,12 @@ fn check_types(
     println!("Found {} type definitions", all_types.len());
     if include_type_literals {
         println!("Found {} type literals", all_type_literals.len());
+    }
+    if show_ignored && !ignored_types.is_empty() {
+        println!("Ignored {} type(s) via similarity-ignore directive:", ignored_types.len());
+        for (file, name, line) in &ignored_types {
+            println!("  {}:{} {}", file, line, name);
+        }
     }
 
     // Set up comparison options
@@ -1021,6 +1045,7 @@ fn check_classes(
     no_implements: bool,
     suggest: bool,
     exclude_patterns: &[String],
+    show_ignored: bool,
 ) -> anyhow::Result<usize> {
     use ignore::WalkBuilder;
     use similarity_core::{extract_classes_from_code, find_similar_classes};
@@ -1117,6 +1142,7 @@ fn check_classes(
     // Extract classes from all files
     let mut all_classes = Vec::new();
     let mut excluded_classes = Vec::new();
+    let mut ignored_classes = Vec::new();
 
     for file in &files {
         match fs::read_to_string(file) {
@@ -1127,6 +1153,17 @@ fn check_classes(
                 match extract_classes_from_code(&content, &file_str) {
                     Ok(classes) => {
                         for class in classes {
+                            if class.has_ignore_directive {
+                                if show_ignored {
+                                    ignored_classes.push((
+                                        file.display().to_string(),
+                                        class.name.clone(),
+                                        class.start_line,
+                                    ));
+                                }
+                                continue;
+                            }
+
                             // Check if class should be excluded
                             let excluded_by_inheritance = no_inheritance && class.extends.is_some();
                             let excluded_by_implements =
@@ -1159,6 +1196,13 @@ fn check_classes(
     }
 
     println!("Found {} class definitions", all_classes.len());
+    if show_ignored && !ignored_classes.is_empty() {
+        println!("Ignored {} class(es) via similarity-ignore directive:", ignored_classes.len());
+        for (file, name, line) in &ignored_classes {
+            println!("  {}:{} {}", file, line, name);
+        }
+        println!();
+    }
 
     if !excluded_classes.is_empty() {
         println!("Excluded {} classes:", excluded_classes.len());

--- a/crates/similarity-ts/src/parallel.rs
+++ b/crates/similarity-ts/src/parallel.rs
@@ -24,7 +24,10 @@ pub fn load_files_parallel(files: &[PathBuf]) -> Vec<FileData> {
                     let filename = file.to_string_lossy();
                     // Extract functions, skip if parse error
                     match extract_functions(&filename, &content) {
-                        Ok(functions) => Some(FileData { path: file.clone(), content, functions }),
+                        Ok(mut functions) => {
+                            functions.retain(|function| !function.has_ignore_directive);
+                            Some(FileData { path: file.clone(), content, functions })
+                        }
                         Err(_) => None, // Skip files with parse errors
                     }
                 }

--- a/crates/similarity-ts/tests/ignore_directives_test.rs
+++ b/crates/similarity-ts/tests/ignore_directives_test.rs
@@ -1,0 +1,112 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn test_similarity_ignore_skips_function_duplicates_and_reports_ignored_items() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("functions.ts");
+
+    fs::write(
+        &file,
+        r#"
+export function calculateTotal(items: number[]): number {
+    let total = 0;
+    for (const item of items) {
+        total += item;
+    }
+    return total;
+}
+
+// similarity-ignore
+export function computeTotal(values: number[]): number {
+    let total = 0;
+    for (const value of values) {
+        total += value;
+    }
+    return total;
+}
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("similarity-ts")
+        .unwrap()
+        .arg(dir.path())
+        .arg("--no-size-penalty")
+        .arg("--show-ignored")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No duplicate functions found!"))
+        .stdout(predicate::str::contains("computeTotal"))
+        .stdout(predicate::str::contains("Ignored"));
+}
+
+#[test]
+fn test_similarity_ignore_skips_type_duplicates() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("types.ts");
+
+    fs::write(
+        &file,
+        r#"
+interface User {
+    id: string;
+    email: string;
+}
+
+// similarity-ignore
+interface IgnoredUser {
+    id: string;
+    email: string;
+}
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("similarity-ts")
+        .unwrap()
+        .arg(dir.path())
+        .arg("--no-functions")
+        .arg("--show-ignored")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No similar types found"))
+        .stdout(predicate::str::contains("IgnoredUser"));
+}
+
+#[test]
+fn test_similarity_ignore_skips_class_duplicates() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("classes.ts");
+
+    fs::write(
+        &file,
+        r#"
+class ServiceA {
+    process(input: string): string {
+        return input.trim().toLowerCase();
+    }
+}
+
+// similarity-ignore
+class ServiceB {
+    process(value: string): string {
+        return value.trim().toLowerCase();
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("similarity-ts")
+        .unwrap()
+        .arg(dir.path())
+        .arg("--classes-only")
+        .arg("--show-ignored")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No similar classes found!"))
+        .stdout(predicate::str::contains("ServiceB"));
+}


### PR DESCRIPTION
## Summary

- add `// similarity-ignore` support for TypeScript functions, types, and classes
- add `--show-ignored` reporting in `similarity-ts`
- add reusable `ConfigLoader` support in `core` and `similarity.toml` loading in `similarity-rs`
- keep existing `similarity-rs` CLI defaults intact while making config file values fallback-only

## Why

Two pending contributions were worth landing together:

- PR #21 proposed an ignore directive to suppress intentional false positives
- PR #23 proposed repository-level config loading for `similarity-rs`

I integrated both ideas into the current codebase, tightened tests, and preserved existing CLI behavior where the original config PR would have changed defaults.

## Impact

- intentionally duplicated TypeScript code can be ignored with `// similarity-ignore`
- ignored symbols can be surfaced explicitly with `--show-ignored`
- `similarity-rs` can load shared defaults from `similarity.toml`
- CLI arguments still take precedence over config values and existing hardcoded defaults stay the same

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --verbose`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::uninlined-format-args -A clippy::only-used-in-recursion`
- `cargo build --workspace --release --verbose`

## Related

- incorporates ideas from #21 and #23