### PR TITLE
Reduce Rust short-function false positives

### DIFF
--- a/crates/similarity-rs/src/parallel.rs
+++ b/crates/similarity-rs/src/parallel.rs
@@ -6,6 +6,7 @@ use similarity_core::{
     language_parser::{GenericFunctionDef, LanguageParser},
     tsed::TSEDOptions,
 };
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
@@ -96,15 +97,17 @@ pub fn check_within_file_duplicates_parallel(
                                             continue;
                                         }
 
-                                        // Extract function bodies
+                                        // Extract full function source so Rust signatures
+                                        // contribute to similarity, reducing false positives
+                                        // on short functions with identical bodies.
                                         let lines: Vec<&str> = code.lines().collect();
-                                        let body1 = extract_function_body(&lines, func1);
-                                        let body2 = extract_function_body(&lines, func2);
+                                        let source1 = extract_function_source(&lines, func1);
+                                        let source2 = extract_function_source(&lines, func2);
 
-                                        // Parse function bodies to trees
+                                        // Parse function source to trees
                                         let (tree1_opt, tree2_opt) = match (
-                                            parser.parse(&body1, &format!("{}:func1", file_str)),
-                                            parser.parse(&body2, &format!("{}:func2", file_str)),
+                                            parser.parse(&source1, &format!("{}:func1", file_str)),
+                                            parser.parse(&source2, &format!("{}:func2", file_str)),
                                         ) {
                                             (Ok(tree1), Ok(tree2)) => {
                                                 // Skip if either tree is empty
@@ -133,8 +136,16 @@ pub fn check_within_file_duplicates_parallel(
                                                 }
                                                 // For Rust, use TSED instead of enhanced similarity
                                                 // to better handle short functions
-                                                similarity_core::tsed::calculate_tsed(
-                                                    &tree1, &tree2, options,
+                                                let body_similarity =
+                                                    similarity_core::tsed::calculate_tsed(
+                                                        &tree1, &tree2, options,
+                                                    );
+                                                blend_rust_similarity(
+                                                    body_similarity,
+                                                    &source1,
+                                                    &source2,
+                                                    func1,
+                                                    func2,
                                                 )
                                             }
                                             _ => 0.0,
@@ -167,25 +178,94 @@ pub fn check_within_file_duplicates_parallel(
         .collect()
 }
 
-/// Extract function body only (excluding signature)
-fn extract_function_body(lines: &[&str], func: &GenericFunctionDef) -> String {
-    // Extract only the body (between body_start_line and body_end_line)
-    // If body_start_line/body_end_line are not set, fall back to using the whole function
-    let start_idx = if func.body_start_line > 0 {
-        (func.body_start_line.saturating_sub(1)) as usize
-    } else {
-        (func.start_line.saturating_sub(1)) as usize
-    };
-
-    let end_idx = if func.body_end_line > 0 {
-        std::cmp::min(func.body_end_line as usize, lines.len())
-    } else {
-        std::cmp::min(func.end_line as usize, lines.len())
-    };
+/// Extract full function source, including the signature.
+fn extract_function_source(lines: &[&str], func: &GenericFunctionDef) -> String {
+    let start_idx = (func.start_line.saturating_sub(1)) as usize;
+    let end_idx = std::cmp::min(func.end_line as usize, lines.len());
 
     if start_idx >= lines.len() {
         return String::new();
     }
 
     lines[start_idx..end_idx].join("\n")
+}
+
+fn blend_rust_similarity(
+    body_similarity: f64,
+    source1: &str,
+    source2: &str,
+    func1: &GenericFunctionDef,
+    func2: &GenericFunctionDef,
+) -> f64 {
+    let max_lines =
+        (func1.end_line - func1.start_line + 1).max(func2.end_line - func2.start_line + 1);
+    let signature_weight = if max_lines <= 8 { 0.35 } else { 0.2 };
+    let signature_similarity = calculate_signature_similarity(source1, source2);
+
+    (body_similarity * (1.0 - signature_weight) + signature_similarity * signature_weight)
+        .clamp(0.0, 1.0)
+}
+
+fn calculate_signature_similarity(source1: &str, source2: &str) -> f64 {
+    let tokens1 = tokenize_signature(extract_signature(source1));
+    let tokens2 = tokenize_signature(extract_signature(source2));
+
+    if tokens1.is_empty() || tokens2.is_empty() {
+        return 0.0;
+    }
+
+    let counts1 = token_counts(tokens1);
+    let counts2 = token_counts(tokens2);
+
+    let mut intersection = 0usize;
+    let mut union = 0usize;
+
+    for (token, count1) in &counts1 {
+        let count2 = counts2.get(token).copied().unwrap_or(0);
+        intersection += (*count1).min(count2);
+        union += (*count1).max(count2);
+    }
+
+    for (token, count2) in &counts2 {
+        if !counts1.contains_key(token) {
+            union += *count2;
+        }
+    }
+
+    if union == 0 {
+        0.0
+    } else {
+        intersection as f64 / union as f64
+    }
+}
+
+fn extract_signature(source: &str) -> &str {
+    source.split('{').next().unwrap_or(source).trim()
+}
+
+fn tokenize_signature(signature: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+
+    for ch in signature.chars() {
+        if ch.is_ascii_alphanumeric() {
+            current.push(ch.to_ascii_lowercase());
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    tokens
+}
+
+fn token_counts(tokens: Vec<String>) -> HashMap<String, usize> {
+    let mut counts = HashMap::new();
+    for token in tokens {
+        *counts.entry(token).or_insert(0) += 1;
+    }
+    counts
 }

--- a/crates/similarity-rs/src/rust_parser.rs
+++ b/crates/similarity-rs/src/rust_parser.rs
@@ -409,6 +409,28 @@ fn find_first_function(node: Node) -> Option<Node> {
     None
 }
 
+fn looks_like_function_item(source: &str) -> bool {
+    let mut remainder = source.trim_start();
+
+    while let Some(line) = remainder.lines().next() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            remainder = &remainder[line.len()..];
+            remainder = remainder.strip_prefix('\n').unwrap_or(remainder);
+            continue;
+        }
+        if trimmed.starts_with("#[") {
+            remainder = &remainder[line.len()..];
+            remainder = remainder.strip_prefix('\n').unwrap_or(remainder);
+            continue;
+        }
+
+        return trimmed.contains("fn ");
+    }
+
+    false
+}
+
 impl LanguageParser for RustParser {
     fn parse(
         &mut self,
@@ -418,12 +440,13 @@ impl LanguageParser for RustParser {
         // Reset node ID counter for each parse
         self.node_id_counter = 0;
 
-        // If the source looks like a function body (starts with whitespace or directly with code),
-        // wrap it in a minimal function context for parsing
-        let wrapped_source = if source.trim_start() != source || !source.starts_with("fn ") {
-            format!("fn __dummy() {{ {source} }}")
-        } else {
+        // Wrap body snippets in a minimal function so tree-sitter can parse them.
+        // Full function items, even when indented or preceded by attributes, should be
+        // parsed as-is so the signature contributes to similarity.
+        let wrapped_source = if looks_like_function_item(source) {
             source.to_string()
+        } else {
+            format!("fn __dummy() {{ {source} }}")
         };
 
         let tree = self.parser.parse(&wrapped_source, None).ok_or_else(|| {

--- a/crates/similarity-rs/tests/integration_test.rs
+++ b/crates/similarity-rs/tests/integration_test.rs
@@ -189,6 +189,47 @@ fn func2(y: i32) -> i32 {
 }
 
 #[test]
+fn test_rust_signature_differences_reduce_short_function_false_positives() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("signature_false_positive.rs");
+
+    let content = r#"
+fn render_count(_text: &str) -> usize {
+    let value = 8080;
+    if value > 0 {
+        value + 1
+    } else {
+        0
+    }
+}
+
+fn cache_ready(_flag: bool) -> i32 {
+    let value = 8080;
+    if value > 0 {
+        value + 1
+    } else {
+        0
+    }
+}
+"#;
+
+    fs::write(&file_path, content).unwrap();
+
+    Command::cargo_bin("similarity-rs")
+        .unwrap()
+        .arg(&file_path)
+        .arg("--threshold")
+        .arg("0.90")
+        .arg("--min-lines")
+        .arg("1")
+        .arg("--min-tokens")
+        .arg("1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No duplicate functions found!"));
+}
+
+#[test]
 fn test_min_lines_filtering() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("min_lines_test.rs");


### PR DESCRIPTION
## Summary

- compare full Rust function source instead of only the extracted body when checking within-file duplicates
- treat indented Rust function items as full function parses so signatures are preserved
- blend in lightweight signature-token similarity for short Rust functions to reduce obvious false positives
- add a regression test for short functions with identical bodies but incompatible signatures

## Why

Issue #19 reports that `similarity-rs` can over-report short Rust functions as duplicates.

The main cause was that the Rust path compared only function bodies, which dropped function names, parameter types, and return types entirely. For short functions, that pushed unrelated code too high.

## Impact

- short Rust functions now include signature information in similarity scoring
- obvious mismatches like `fn foo(&str) -> usize` vs `fn bar(bool) -> i32` are less likely to be reported as duplicates
- existing duplicate detection for genuinely similar Rust functions remains covered by tests

## Validation

- `cargo test -p similarity-rs`
- `cargo test -p similarity-rs --test skip_test_option -- --nocapture`
- `cargo test -p similarity-rs test_rust_signature_differences_reduce_short_function_false_positives -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p similarity-rs --all-targets -- -D warnings -A clippy::uninlined-format-args -A clippy::only-used-in-recursion`

## Related

- fixes #19